### PR TITLE
feat: add shopware-version action

### DIFF
--- a/.github/actions/shopware-version/action.yml
+++ b/.github/actions/shopware-version/action.yml
@@ -1,0 +1,44 @@
+name: shopware-version
+description: "Action to get the shopware version that is matching the current branch. Returns a fallback if no matching branch is found."
+author: "shopware AG"
+branding:
+  color: "blue"
+  icon: "download"
+
+inputs:
+  fallback:
+    description: The fallback that is returned if there's no matching branch
+    default: trunk
+    required: false
+
+outputs:
+  shopware-version:
+    description: The matching shopware version or fallback
+    value: ${{ steps.get-version.outputs.shopware-version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get shopware version
+      id: get-version
+      shell: bash
+      run: |
+        if [[ -n "${{ github.head_ref }}" ]]; then
+          ref="refs/heads/${{ github.head_ref }}"
+        else
+          ref="${{ github.ref }}"
+        fi
+
+        echo "Local ref: $ref"
+
+        remote_ref=$(git ls-remote --heads "https://github.com/shopware/shopware" "$ref" | cut -f 2)
+        if [[ -n "$remote_ref" ]]; then
+          version="${remote_ref#"refs/heads/"}"
+        else
+          echo "No matching branch found, using fallback"
+          version="${{ inputs.fallback }}"
+        fi
+
+        echo "Matching shopware version: $version"
+
+        echo "shopware-version=$version" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Add action to get a suitable shopware version. Will use the same ref as the repo using the action, if it exists. If it does not exist it will use the fallback, which is `trunk` by default.

Example workflow:
```yaml
name: Test
on:
  pull_request:
  push:
  workflow_dispatch:

jobs:
  jest:
    runs-on: ubuntu-latest
    steps:
      - uses: shopware/github-actions/.github/actions/shopware-version@add-shopware-version-action
        with:
          fallback: "6.5.x"
        id: version
      - name: Setup Shopware
        uses: shopware/setup-shopware@main
        with:
          shopware-version: ${{ steps.version.outputs.shopware-version }}
      - name: Print version
        shell: bash
        run: bin/console --version

```