### PR TITLE
fix: install admin deps in eslint workflow

### DIFF
--- a/.github/workflows/admin-eslint.yml
+++ b/.github/workflows/admin-eslint.yml
@@ -45,6 +45,11 @@ jobs:
         with:
           node-version: '20.x'
 
+      - name: Install admin deps
+        shell: bash
+        working-directory: src/Administration/Resources/app/administration
+        run: npm ci --no-audit --no-fund --prefer-offline
+
       - name: Install Plugin Dependencies
         working-directory: custom/plugins/${{ inputs.extensionName }}/src/Resources/app/administration
         run: npm install --no-audit --no-fund --prefer-offline


### PR DESCRIPTION
 some plugins require the admin deps to be installed for type information