### PR TITLE
feat: allow branch in dependencies

### DIFF
--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -107,7 +107,11 @@ runs:
         for dep in $(echo "$DEPS" | envsubst | jq -c '.[]'); do
           dep_name=$(echo "$dep" | jq -r '.name')
           dep_repo=$(echo "$dep" | jq -r '.repo')
+          dep_branch=$(echo "$dep" | jq -r '.branch // empty')
           git clone "$dep_repo" "custom/plugins/$dep_name"
+          if [ ! -z "${dep_branch}" ]; then
+            git -C custom/plugins/${dep_name} checkout ${dep_branch}
+          fi
         done
 
     - name: Install dependencies with Composer


### PR DESCRIPTION
Currently we always checkout the default branch in our dependencies. Some of our workflows need to checkout a different branch of a dependency.