### PR TITLE
fix: path input indentation

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -3,14 +3,14 @@ on:
   workflow_call:
     inputs:
       extensionName:
-        description: 'Your extension name'
+        description: "Your extension name"
         required: true
         type: string
-    path:
-      description: "Path to your bundle"
-      required: false
-      type: string
-      default: "."
+      path:
+        description: "Path to your bundle"
+        required: false
+        type: string
+        default: "."
 jobs:
   run:
     name: Build and Validate


### PR DESCRIPTION
#32 broke the build-zip workflow. `path` got a wrong indentation.