### PR TITLE
feat: add token to dependencies in setup-extension

### DIFF
--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -121,8 +121,14 @@ runs:
           dep_name=$(echo "$dep" | jq -r '.name')
           dep_repo=$(echo "$dep" | jq -r '.repo')
           dep_branch=$(echo "$dep" | jq -r '.branch // empty')
-          git clone "$dep_repo" "custom/plugins/$dep_name"
-          if [ ! -z "${dep_branch}" ]; then
+          dep_token=$(echo "$dep" | jq -r '.token // empty')
+          if [ -n "${dep_token}" ]; then
+            # if a custom token is provided use this token to clone
+            git clone -c "http.${dep_repo}/.extraheader=AUTHORIZATION: basic $(echo -n "x-access-token:${dep_token}" | base64)" "${dep_repo}" "custom/plugins/${dep_name}"
+          else
+            git clone "$dep_repo" "custom/plugins/$dep_name"
+          fi
+          if [ -n "${dep_branch}" ]; then
             git -C custom/plugins/${dep_name} checkout ${dep_branch}
           fi
         done


### PR DESCRIPTION
Currently we are cloning with the `GITHUB_TOKEN` that was set by the last `actions/checkout` action.
A dependency can also be private and need to be cloned with a different token.

With this change we can set the optional "token" in the dependency and then we will use it to clone the dependency with that token.
Example:
```
- uses: shopware/github-actions/setup-extension@feat/add-token-to-dependencies
  with:
    extensionName: ${{ github.event.repository.name }}
    dependencies: |
    [
        {
            "name":"MyExtension",
            "repo": "https://github.com/user/MyExtension.git",
            "token": "${{ secret.TOKEN }}"
        }
    ]
```