### PR TITLE
fix: phpunit action should only do phpunit things and set COMPOSER_ROOT_VERSION for reusable Workflows

### DIFF
--- a/.github/workflows/admin-jest.yml
+++ b/.github/workflows/admin-jest.yml
@@ -36,49 +36,21 @@ jobs:
     name: Jest
     runs-on: ubuntu-latest
     steps:
-      - uses: shopware/github-actions/shopware-version@main
+      - name: Setup Extension
+        uses: shopware/github-actions/setup-extension@main
         with:
-          fallback: ${{ inputs.shopwareVersionFallback }}
-        id: version
-        if: ${{ inputs.shopwareVersion == '.auto' }}
-      - name: Setup Shopware
-        uses: shopware/setup-shopware@main
-        with:
-          shopware-version: ${{ steps.version.outputs.shopware-version || inputs.shopwareVersion }}
-          php-version: 8.2
+          extensionName: ${{ github.event.repository.name }}
+          install: true
+          installAdmin: true
           env: prod
-          install: "true"
-
-      - name: Clone Extension
-        uses: actions/checkout@v4
-        with:
-          path: custom/plugins/${{ inputs.extensionName }}
-
-      - name: Refresh Plugins
-        run: php bin/console plugin:refresh
-
-      - name: Install Plugin
-        run: php bin/console plugin:install --activate ${{ inputs.extensionName }}
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20.x"
-
-      - name: Install Administration dependencies
-        working-directory: src/Administration/Resources/app/administration
-        run: npm install --no-audit --no-fund --prefer-offline
-
-      - name: Prepare Jest environment
-        working-directory: src/Administration/Resources/app/administration
-        run: npm run unit-setup
-
-      - name: Generate Entity Schema
-        run: php bin/console framework:schema -s 'entity-schema' src/Administration/Resources/app/administration/test/_mocks_/entity-schema.json
-
-      - name: Install Plugin Dependencies
-        working-directory: custom/plugins/${{ inputs.extensionName }}/src/Resources/app/administration
-        run: npm install --no-audit --no-fund --prefer-offline
+          extraRepositories: |
+            {
+              "${{ github.event.repository.name }}": {
+                "type": "path",
+                "url": "custom/plugins/${{ github.event.repository.name }}",
+                "symlink": true
+              }
+            }
 
       - name: Jest Unit Tests
         working-directory: custom/plugins/${{ inputs.extensionName }}/src/Resources/app/administration

--- a/.github/workflows/admin-jest.yml
+++ b/.github/workflows/admin-jest.yml
@@ -2,91 +2,94 @@ name: Jest
 on:
   workflow_call:
     inputs:
-        extensionName:
-          description: 'Your extension name'
-          required: true
-          type: string
-        shopwareVersion:
-          description: |
-            With the default `.auto`, the workflow tries to find a shopware version using the shopware-version action.
+      extensionName:
+        description: "Your extension name"
+        required: true
+        type: string
+      shopwareVersion:
+        description: |
+          With the default `.auto`, the workflow tries to find a shopware version using the shopware-version action.
 
-            For example, if the current ref is next-1234, it will try to find the ref next-1234 in shopware/shopware. If there's no matching ref, it will use shopwareVersionFallback
-          required: false
-          type: string
-          default: '.auto'
-        shopwareVersionFallback:
-          required: false
-          type: string
-          default: trunk
-        uploadCoverage:
-          description: 'Upload coverage to codecov'
-          required: false
-          type: boolean
-          default: false
+          For example, if the current ref is next-1234, it will try to find the ref next-1234 in shopware/shopware. If there's no matching ref, it will use shopwareVersionFallback
+        required: false
+        type: string
+        default: ".auto"
+      shopwareVersionFallback:
+        required: false
+        type: string
+        default: trunk
+      uploadCoverage:
+        description: "Upload coverage to codecov"
+        required: false
+        type: boolean
+        default: false
     secrets:
       codecovToken:
-        description: 'Codecov token'
+        description: "Codecov token"
         required: false
 
-jobs:
-    run:
-        name: Jest
-        runs-on: ubuntu-latest
-        steps:
-            - uses: shopware/github-actions/shopware-version@main
-              with:
-                fallback: ${{ inputs.shopwareVersionFallback }}
-              id: version
-              if: ${{ inputs.shopwareVersion == '.auto' }}
-            - name: Setup Shopware
-              uses: shopware/setup-shopware@main
-              with:
-                shopware-version:  ${{ steps.version.outputs.shopware-version || inputs.shopwareVersion }}
-                php-version: 8.2
-                env: prod
-                install: 'true'
-    
-            - name: Clone Extension
-              uses: actions/checkout@v4
-              with:
-                path: custom/plugins/${{ inputs.extensionName }}
-        
-            - name: Refresh Plugins
-              run: php bin/console plugin:refresh
-        
-            - name: Install Plugin
-              run: php bin/console plugin:install --activate ${{ inputs.extensionName }}
-        
-            - name: Setup Node
-              uses: actions/setup-node@v4
-              with:
-                node-version: '20.x'
-        
-            - name: Install Administration dependencies
-              working-directory: src/Administration/Resources/app/administration
-              run: npm install --no-audit --no-fund --prefer-offline
-        
-            - name: Prepare Jest environment
-              working-directory: src/Administration/Resources/app/administration
-              run: npm run unit-setup
-        
-            - name: Generate Entity Schema
-              run: php bin/console framework:schema -s 'entity-schema' src/Administration/Resources/app/administration/test/_mocks_/entity-schema.json
-        
-            - name: Install Plugin Dependencies
-              working-directory: custom/plugins/${{ inputs.extensionName }}/src/Resources/app/administration
-              run: npm install --no-audit --no-fund --prefer-offline
-        
-            - name: Jest Unit Tests
-              working-directory: custom/plugins/${{ inputs.extensionName }}/src/Resources/app/administration
-              run: npm run unit -- --coverage
+env:
+  COMPOSER_ROOT_VERSION: 6.6.9999999-dev
 
-            - name: Upload Coverage
-              if: inputs.uploadCoverage == true
-              uses: codecov/codecov-action@v4
-              env:
-                CODECOV_TOKEN: ${{ secrets.codecovToken }}
-              with:
-                root_dir: ${{ github.workspace }}/custom/plugins/${{ inputs.extensionName }}
-                working-directory: ${{ github.workspace }}/custom/plugins/${{ inputs.extensionName }}
-                directory: ${{ github.workspace }}/custom/plugins/${{ inputs.extensionName }}/src/Resources/app/administration
+jobs:
+  run:
+    name: Jest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shopware/github-actions/shopware-version@main
+        with:
+          fallback: ${{ inputs.shopwareVersionFallback }}
+        id: version
+        if: ${{ inputs.shopwareVersion == '.auto' }}
+      - name: Setup Shopware
+        uses: shopware/setup-shopware@main
+        with:
+          shopware-version: ${{ steps.version.outputs.shopware-version || inputs.shopwareVersion }}
+          php-version: 8.2
+          env: prod
+          install: "true"
+
+      - name: Clone Extension
+        uses: actions/checkout@v4
+        with:
+          path: custom/plugins/${{ inputs.extensionName }}
+
+      - name: Refresh Plugins
+        run: php bin/console plugin:refresh
+
+      - name: Install Plugin
+        run: php bin/console plugin:install --activate ${{ inputs.extensionName }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20.x"
+
+      - name: Install Administration dependencies
+        working-directory: src/Administration/Resources/app/administration
+        run: npm install --no-audit --no-fund --prefer-offline
+
+      - name: Prepare Jest environment
+        working-directory: src/Administration/Resources/app/administration
+        run: npm run unit-setup
+
+      - name: Generate Entity Schema
+        run: php bin/console framework:schema -s 'entity-schema' src/Administration/Resources/app/administration/test/_mocks_/entity-schema.json
+
+      - name: Install Plugin Dependencies
+        working-directory: custom/plugins/${{ inputs.extensionName }}/src/Resources/app/administration
+        run: npm install --no-audit --no-fund --prefer-offline
+
+      - name: Jest Unit Tests
+        working-directory: custom/plugins/${{ inputs.extensionName }}/src/Resources/app/administration
+        run: npm run unit -- --coverage
+
+      - name: Upload Coverage
+        if: inputs.uploadCoverage == true
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.codecovToken }}
+        with:
+          root_dir: ${{ github.workspace }}/custom/plugins/${{ inputs.extensionName }}
+          working-directory: ${{ github.workspace }}/custom/plugins/${{ inputs.extensionName }}
+          directory: ${{ github.workspace }}/custom/plugins/${{ inputs.extensionName }}/src/Resources/app/administration

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -6,7 +6,7 @@ on:
         required: false
     inputs:
       extensionName:
-        description: 'Your extension name'
+        description: "Your extension name"
         required: true
         type: string
       shopwareVersion:
@@ -16,7 +16,7 @@ on:
           For example, if the current ref is next-1234, it will try to find the ref next-1234 in shopware/shopware. If there's no matching ref, it will use shopwareVersionFallback
         required: false
         type: string
-        default: '.auto'
+        default: ".auto"
       shopwareVersionFallback:
         required: false
         type: string
@@ -26,6 +26,8 @@ on:
         type: string
 env:
   SHOPWARE_TOOL_CACHE_PHPSTAN: ${{ github.workspace }}/var/phpstan
+  COMPOSER_ROOT_VERSION: 6.6.9999999-dev
+
 jobs:
   run:
     name: Static Analyse
@@ -39,10 +41,10 @@ jobs:
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:
-          shopware-version:  ${{ steps.version.outputs.shopware-version || inputs.shopwareVersion }}
+          shopware-version: ${{ steps.version.outputs.shopware-version || inputs.shopwareVersion }}
           php-version: 8.2
           env: prod
-          install: 'true'
+          install: "true"
       - name: Clone Extension
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       extensionName:
-        description: 'Your extension name'
+        description: "Your extension name"
         required: true
         type: string
       shopwareVersion:
@@ -13,7 +13,7 @@ on:
           For example, if the current ref is next-1234, it will try to find the ref next-1234 in shopware/shopware. If there's no matching ref, it will use shopwareVersionFallback
         required: false
         type: string
-        default: '.auto'
+        default: ".auto"
       shopwareVersionFallback:
         required: false
         type: string
@@ -21,26 +21,30 @@ on:
       phpVersion:
         required: false
         type: string
-        default: '8.2'
+        default: "8.2"
       mysqlVersion:
         required: false
         type: string
-        default: 'builtin'
+        default: "builtin"
       dependencies:
         required: false
         type: string
       uploadCoverage:
-        description: 'Upload coverage to codecov'
+        description: "Upload coverage to codecov"
         required: false
         type: boolean
         default: false
     secrets:
       codecovToken:
-        description: 'Codecov token'
+        description: "Codecov token"
         required: false
       env:
-        description: 'ENV variables to substitute in to plugin repository urls'
+        description: "ENV variables to substitute in to plugin repository urls"
         required: false
+
+env:
+  COMPOSER_ROOT_VERSION: 6.6.9999999-dev
+
 jobs:
   run:
     name: Tests
@@ -67,7 +71,7 @@ jobs:
         env:
           DEPS: ${{ inputs.dependencies }}
         run: |
-          IFS=$'\n' 
+          IFS=$'\n'
           for token in $(echo "${{secrets.env}}"); do
             export $token
           done

--- a/phpunit/action.yml
+++ b/phpunit/action.yml
@@ -1,5 +1,5 @@
 name: "PHPUnit"
-description: "Install shopware and run phpunit"
+description: "phpunit"
 author: "shopware AG"
 branding:
   color: "blue"
@@ -9,28 +9,6 @@ inputs:
   extensionName:
     description: "Your extension name"
     required: true
-  shopwareVersion:
-    description: |
-      With the default `.auto`, the workflow tries to find a shopware version using the shopware-version action.
-
-      For example, if the current ref is next-1234, it will try to find the ref next-1234 in shopware/shopware. If there's no matching ref, it will use shopwareVersionFallback
-    required: false
-    default: ".auto"
-  shopwareVersionFallback:
-    description: Fallback version in case there's no matching branch
-    required: false
-    default: trunk
-  phpVersion:
-    description: PHP version to use
-    required: false
-    default: "8.2"
-  mysqlVersion:
-    description: Mysql image to use or buildin to use the builtin mysql
-    required: false
-    default: "builtin"
-  dependencies:
-    description: JSON list defining dependencies
-    required: false
   uploadCoverage:
     description: "Upload coverage to codecov. Requires token in CODECOV_TOKEN"
     required: false
@@ -39,45 +17,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: shopware/github-actions/shopware-version@main
-      with:
-        fallback: ${{ inputs.shopwareVersionFallback }}
-      id: version
-      if: ${{ inputs.shopwareVersion == '.auto' }}
-    - name: Setup Shopware
-      uses: shopware/setup-shopware@main
-      with:
-        shopware-version: ${{ steps.version.outputs.shopware-version || inputs.shopwareVersion }}
-        php-version: ${{ inputs.phpVersion }}
-        mysql-version: ${{ inputs.mysqlVersion }}
-        php-extensions: pcov
-    - name: Clone Extension
-      uses: actions/checkout@v4
-      with:
-        path: custom/plugins/${{ inputs.extensionName }}
-    - name: Clone Dependencies
-      shell: bash
-      if: inputs.dependencies
-      env:
-        DEPS: ${{ inputs.dependencies }}
-      run: |
-        for dep in $(echo "$DEPS" | envsubst | jq -c '.[]'); do
-          dep_name=$(echo "$dep" | jq -r '.name')
-          dep_repo=$(echo "$dep" | jq -r '.repo')
-          git clone "$dep_repo" "custom/plugins/$dep_name"
-        done
-    - name: Install extension with Composer
-      shell: bash
-      run: |
-        composer require $(composer -d custom/plugins/${{ inputs.extensionName }} config name)
-        if [[ ! -L "custom/plugins/${{ inputs.extensionName }}" ]]; then
-          echo "custom/plugins/${{ inputs.extensionName }} should be a symlink"
-          exit 1
-        fi
     - name: Run PHPUnit
       shell: bash
       working-directory: custom/plugins/${{ inputs.extensionName }}
-      run: ${{ github.workspace }}/vendor/bin/phpunit --coverage-clover clover.xml
+      run: ${GITHUB_WORKSPACE}/vendor/bin/phpunit --coverage-clover clover.xml
     - name: Upload Coverage
       if: inputs.uploadCoverage == true
       uses: codecov/codecov-action@v4


### PR DESCRIPTION
The `phpunit` action also installed shopware. The action should only do things related to its name.

And if we are using a different branch than trunk as platform branch the reusable workflows will fail on the composer steps. We should set the `COMPOSER_ROOT_VERSION` in the workflows.