### PR TITLE
fix: remove COMPOSER_ROOT_VERSION and set it in setup-shopware

### DIFF
--- a/.github/workflows/admin-jest.yml
+++ b/.github/workflows/admin-jest.yml
@@ -18,6 +18,10 @@ on:
         required: false
         type: string
         default: trunk
+      composerRootVersion:
+        required: false
+        type: string
+        default: ".auto"
       uploadCoverage:
         description: "Upload coverage to codecov"
         required: false
@@ -28,9 +32,6 @@ on:
         description: "Codecov token"
         required: false
 
-env:
-  COMPOSER_ROOT_VERSION: 6.6.9999999-dev
-
 jobs:
   run:
     name: Jest
@@ -40,6 +41,7 @@ jobs:
         uses: shopware/github-actions/setup-extension@main
         with:
           extensionName: ${{ github.event.repository.name }}
+          composerRootVersion: ${{ inputs.composerRootVersion }}
           install: true
           installAdmin: true
           env: prod

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -21,12 +21,15 @@ on:
         required: false
         type: string
         default: trunk
+      composerRootVersion:
+        required: false
+        type: string
+        default: ".auto"
       dependencies:
         required: false
         type: string
 env:
   SHOPWARE_TOOL_CACHE_PHPSTAN: ${{ github.workspace }}/var/phpstan
-  COMPOSER_ROOT_VERSION: 6.6.9999999-dev
 
 jobs:
   run:
@@ -42,6 +45,7 @@ jobs:
         uses: shopware/setup-shopware@main
         with:
           shopware-version: ${{ steps.version.outputs.shopware-version || inputs.shopwareVersion }}
+          composer-root-version: ${{ inputs.composerRootVersion }}
           php-version: 8.2
           env: prod
           install: "true"

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -26,6 +26,10 @@ on:
         required: false
         type: string
         default: "builtin"
+      composerRootVersion:
+        required: false
+        type: string
+        default: ".auto"
       dependencies:
         required: false
         type: string
@@ -41,9 +45,6 @@ on:
       env:
         description: "ENV variables to substitute in to plugin repository urls"
         required: false
-
-env:
-  COMPOSER_ROOT_VERSION: 6.6.9999999-dev
 
 jobs:
   run:
@@ -61,6 +62,7 @@ jobs:
           shopware-version: ${{ steps.version.outputs.shopware-version || inputs.shopwareVersion }}
           php-version: ${{ inputs.phpVersion }}
           mysql-version: ${{ inputs.mysqlVersion }}
+          composer-root-version: ${{ inputs.composerRootVersion }}
           php-extensions: pcov
       - name: Clone Extension
         uses: actions/checkout@v4

--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: nodejs version to use
     required: false
     default: "20.x"
+  composerRootVersion:
+    description: "The COMPOSER_ROOT_VERSION that should be set"
+    required: false
+    default: ".auto"
 
   dependencies:
     description: JSON list defining dependencies
@@ -89,6 +93,7 @@ runs:
         php-version: ${{ inputs.phpVersion }}
         mysql-version: ${{ inputs.mysqlVersion }}
         node-version: ${{ inputs.node-version }}
+        composer-root-version: ${{ inputs.composerRootVersion }}
         install: ${{ inputs.install }}
         installAdmin: ${{ inputs.installAdmin }}
         installStorefront: ${{ inputs.installStorefront }}


### PR DESCRIPTION
Remove the `COMPOSER_ROOT_VERSION` from the actions of this repo as it is now set in `setup-extension`.
https://github.com/shopware/setup-shopware/pull/7