### PR TITLE
fix: adjust version input check in order not to skip shopware-version…

### DIFF
--- a/.github/workflows/admin-eslint.yml
+++ b/.github/workflows/admin-eslint.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           fallback: ${{ inputs.shopwareVersionFallback }}
         id: version
-        if: ${{ inputs.shopwareVersion == '.auto' }}
+        if: ${{ inputs.shopwareVersion == '' }}
+
       - name: Clone Shopware
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -40,7 +40,7 @@ jobs:
         with:
           fallback: ${{ inputs.shopwareVersionFallback }}
         id: version
-        if: ${{ inputs.shopwareVersion == '.auto' }}
+        if: ${{ inputs.shopwareVersion == '' }}
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           fallback: ${{ inputs.shopwareVersionFallback }}
         id: version
-        if: ${{ inputs.shopwareVersion == '.auto' }}
+        if: ${{ inputs.shopwareVersion == '' }}
       - name: Setup Shopware
         uses: shopware/setup-shopware@main
         with:

--- a/eslint/action.yml
+++ b/eslint/action.yml
@@ -42,7 +42,8 @@ runs:
       with:
         fallback: ${{ inputs.shopwareVersionFallback }}
       id: version
-      if: ${{ inputs.shopwareVersion == '.auto' }}
+      if: ${{ inputs.shopwareVersion == '' }}
+
     - name: Clone Shopware
       uses: actions/checkout@v4
       with:

--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -85,7 +85,8 @@ runs:
       with:
         fallback: ${{ inputs.shopwareVersionFallback }}
       id: version
-      if: ${{ inputs.shopwareVersion == '.auto' }}
+      if: ${{ inputs.shopwareVersion == '' }}
+
     - name: Setup Shopware
       uses: shopware/setup-shopware@main
       with:


### PR DESCRIPTION
… action

---

With the following debugging step added to the eslint workflow:

```yaml
    - uses: shopware/github-actions/shopware-version@main
      with:
        fallback: ${{ inputs.shopwareVersionFallback }}
      id: version
      if: ${{ inputs.shopwareVersion == '.auto' }}

    - name: Crash everything, because we got '.auto'
      run: |
        echo "version step was executed: ${{ steps.version.conclusion }}"
        echo "Shopware-Version: ${{ steps.version.outputs.shopware-version }}"
        echo "Shopware-Input: ${{ inputs.shopwareVersion }}"
        exit 1
      if: ${{ inputs.shopwareVersion == '.auto' }}
```

I get the following output:

```
[Admin/ESLint] ⭐ Run Pre shopware/github-actions/eslint@main
[Admin/ESLint] ⭐ Run Pre shopware/github-actions/shopware-version@main
[Admin/ESLint]   ✅  Success - Pre shopware/github-actions/shopware-version@main
[Admin/ESLint]   ✅  Success - Pre shopware/github-actions/eslint@main
[Admin/ESLint] ⭐ Run Main shopware/github-actions/eslint@main
[Admin/ESLint] ⭐ Run Main Crash everything, because we got '.auto'
[Admin/ESLint]   🐳  docker exec cmd=[bash -e /var/run/act/workflow/0-composite-1] user= workdir=
| version step was executed: skipped
| Shopware-Version: 
| Shopware-Input: .auto
[Admin/ESLint]   ❌  Failure - Main Crash everything, because we got '.auto'
```

So the `shopwareVersion` is `.auto`, but the `version` step is still skipped, although its condition is `if: ${{ inputs.shopwareVersion == '.auto' }}`.

Considering that the default value isn't evaluated in conditionals, I propose this change to fix workflows that depend on dynamically determining the shopware version.