### PR TITLE
fix: use GITHUB_WORKSPACE instead of github.workspace

### DIFF
--- a/phpstan/action.yml
+++ b/phpstan/action.yml
@@ -30,8 +30,8 @@ runs:
           ${{ runner.OS }}-${{ github.repository }}-phpstan-
     - name: Build PHPStan Bootstrap
       shell: bash
-      run: php ${{ github.workspace }}/src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php
+      run: php ${GITHUB_WORKSPACE}/src/Core/DevOps/StaticAnalyze/phpstan-bootstrap.php
     - name: Run PHPStan
       shell: bash
       working-directory: custom/plugins/${{ inputs.extensionName }}
-      run: ${{ github.workspace }}/vendor/bin/phpstan analyze --error-format=github --no-progress
+      run: ${GITHUB_WORKSPACE}/vendor/bin/phpstan analyze --error-format=github --no-progress


### PR DESCRIPTION
On the k8s self-hosted runners the github.workspace variable gets resolved wrong. The GITHUB_WORKSPACE environment variables contains the correct resolved path on both runner types, official and self-hosted.