### PR TITLE
feat: add npm version

### DIFF
--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -209,7 +209,7 @@ runs:
       if: ${{ inputs.install && inputs.install-admin }}
       shell: bash
       working-directory: src/Administration/Resources/app/administration
-      run: npm run unit-setup
+      run: npm run unit-setup --if-present
 
     - name: Entity schema
       if: ${{ inputs.install && inputs.install-admin }}


### PR DESCRIPTION
Some plugins require older versions of npm.
When we now set npm-version it will install the specified npm version.

I also fixed the npm run unit-setup. Some older versions doesn't have such a npm script, so we only run it when it is present.

Requires: https://github.com/shopware/setup-shopware/pull/17