### PR TITLE
feat: Allow skip of recheckout

### DIFF
--- a/build-zip/action.yml
+++ b/build-zip/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "Path to your bundle"
     required: false
     default: "."
+  skipCheckout:
+    description: "Skip the checkout step"
+    required: false
+    default: 'false'
 
 outputs:
   artifact-id:
@@ -26,6 +30,7 @@ runs:
   using: "composite"
   steps:
     - uses: actions/checkout@v4
+      if: inputs.skipCheckout == 'false'
     - name: Install shopware-cli
       uses: FriendsOfShopware/shopware-cli-action@v1
     - name: Build

--- a/store-release/action.yml
+++ b/store-release/action.yml
@@ -26,6 +26,10 @@ inputs:
   ghToken:
     description: "GitHub token"
     required: true
+  skipCheckout:
+    description: "Skip the checkout step"
+    required: false
+    default: 'false'
 
 runs:
   using: "composite"
@@ -33,6 +37,7 @@ runs:
     - uses: shopware/build-zip@main
       with:
         extensionName: ${{ inputs.extensionName }}
+        skipCheckout: ${{ inputs.skipCheckout }}
 
     - name: Get version
       shell: bash


### PR DESCRIPTION
We need to do some preparation before using the shopware-cli. Namely, we want to template the manifest.xml and any hooks defined for the shopware-cli will fail because the manifest.xml won't be found initially and the repo won't be identified as app.