### PR TITLE
fix: activate app after installing

### DIFF
--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -212,7 +212,7 @@ runs:
       if: ${{ inputs.install && env.IS_APP == 'true' }}
       shell: bash
       run: |-
-        bin/console app:refresh -n ${{ inputs.extensionName }}
+        bin/console app:refresh -n -a ${{ inputs.extensionName }}
 
     - name: Install storefront deps
       if: ${{ inputs.install-storefront }}


### PR DESCRIPTION
I forgot to add the `-a|--activate` flag in my recent PR #50