### PR TITLE
Update actions to reflect ownership change of shopware-cli-action

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install shopware-cli
-        uses: FriendsOfShopware/shopware-cli-action@v1
+        uses: shopware/shopware-cli-action@v1
       - name: Build
         run: shopware-cli extension zip "${{ inputs.path }}" --git-commit "${{ github.sha }}"
       - name: Rename


### PR DESCRIPTION
This pull request includes a change to the GitHub Actions workflow configuration file to update the action used for installing the Shopware CLI.

* [`.github/workflows/build-zip.yml`](diffhunk://#diff-139f590057357be1f0820cc0a36a113091625d66d7424ca6b7cf4118d72b693cL21-R21): Updated the `Install shopware-cli` step to use the `shopware/shopware-cli-action@v1` action instead of the `FriendsOfShopware/shopware-cli-action@v1` action.