### PR TITLE
revert: feat: use fallbacks on empty version strings

### DIFF
--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -96,7 +96,7 @@ runs:
       with:
         fallback: ${{ inputs.shopwareVersionFallback }}
       id: version
-      if: ${{ inputs.shopwareVersion == '.auto' || inputs.shopwareVersion == '' }}
+      if: ${{ inputs.shopwareVersion == '.auto' }}
 
     - name: Setup Shopware
       uses: shopware/setup-shopware@main
@@ -142,7 +142,7 @@ runs:
       run: |-
         echo "IS_PLUGIN=${IS_PLUGIN}" >> $GITHUB_ENV
         echo "IS_APP=${IS_APP}" >> $GITHUB_ENV
-
+        
         if [ "${IS_PLUGIN}" == "false" ] && [ "${IS_APP}" == "false" ]; then
           ls -lah custom/plugins/${{ inputs.extensionName }}
           echo "Neither a plugin nor an app found at custom/plugins/${{ inputs.extensionName }}. Exiting."

--- a/shopware-version/action.yml
+++ b/shopware-version/action.yml
@@ -40,7 +40,7 @@ runs:
             version="${remote_ref#"refs/heads/"}"
           else
             echo "No matching branch found, using fallback"
-            version="${{ inputs.fallback || "trunk" }}"
+            version="${{ inputs.fallback }}"
           fi
         fi
 


### PR DESCRIPTION
Did not work for some reason

![image](https://github.com/user-attachments/assets/41110996-a6cd-4042-990e-c6c6f998860a)


Reverts shopware/github-actions#57