### PR TITLE
feat: use fallbacks on empty version strings (2)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
                 fallback: ""
             - name: Check shopware-version is never empty 
               run: |
-                SHOPWARE_VERSION="${{ steps.version.outputs.shopware-version-test }}"
+                SHOPWARE_VERSION="${{ steps.version.outputs.shopware-version }}"
                 echo "shopware-version: '${SHOPWARE_VERSION}'"
                 if [[ -z "${SHOPWARE_VERSION}" ]]; then
                     echo 'shopware-version should not be empty'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
               run: |
                 SHOPWARE_VERSION="${{ steps.version.outputs.shopware-version-test }}"
                 echo "shopware-version: '${SHOPWARE_VERSION}'"
-                if [[ -n "${SHOPWARE_VERSION}" ]]; then
+                if [[ -z "${SHOPWARE_VERSION}" ]]; then
                     echo 'shopware-version should not be empty'
                     exit 1
                 fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test actions
+on:
+  pull_request:
+
+jobs:
+    shopware-version:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - id: version
+              uses: ./setup-version
+              with:
+                fallback: fallback-value
+            - name: Check shopware-version is never empty 
+              run: |
+                [[ -n "${{ steps.version.outputs.shopware-version }}" ]]
+
+                
+
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
             - id: version
-              uses: ./setup-version
+              uses: ./shopware-version
               with:
                 fallback: fallback-value
             - name: Check shopware-version is never empty 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,12 @@ jobs:
                 fallback: ""
             - name: Check shopware-version is never empty 
               run: |
-                [[ -n "${{ steps.version.outputs.shopware-versionasdf }}" ]]
+                SHOPWARE_VERSION="${{ steps.version.outputs.shopware-version-test }}"
+                echo "shopware-version: '${SHOPWARE_VERSION}'"
+                if [[ -n "${SHOPWARE_VERSION}" ]]; then
+                    echo 'shopware-version should not be empty'
+                    exit 1
+                fi
 
                 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
             - id: version
               uses: ./shopware-version
               with:
-                fallback: fallback-value
+                fallback: ""
             - name: Check shopware-version is never empty 
               run: |
-                [[ -n "${{ steps.version.outputs.shopware-version }}" ]]
+                [[ -n "${{ steps.version.outputs.shopware-versionasdf }}" ]]
 
                 
 

--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -96,7 +96,7 @@ runs:
       with:
         fallback: ${{ inputs.shopwareVersionFallback }}
       id: version
-      if: ${{ inputs.shopwareVersion == '.auto' }}
+      if: ${{ inputs.shopwareVersion == '.auto' || inputs.shopwareVersion == '' }}
 
     - name: Setup Shopware
       uses: shopware/setup-shopware@main
@@ -142,7 +142,7 @@ runs:
       run: |-
         echo "IS_PLUGIN=${IS_PLUGIN}" >> $GITHUB_ENV
         echo "IS_APP=${IS_APP}" >> $GITHUB_ENV
-        
+
         if [ "${IS_PLUGIN}" == "false" ] && [ "${IS_APP}" == "false" ]; then
           ls -lah custom/plugins/${{ inputs.extensionName }}
           echo "Neither a plugin nor an app found at custom/plugins/${{ inputs.extensionName }}. Exiting."

--- a/shopware-version/action.yml
+++ b/shopware-version/action.yml
@@ -40,7 +40,7 @@ runs:
             version="${remote_ref#"refs/heads/"}"
           else
             echo "No matching branch found, using fallback"
-            version="${{ inputs.fallback }}"
+            version="${{ inputs.fallback || 'trunk' }}"
           fi
         fi
 


### PR DESCRIPTION
Second try

- [x] test it first 🙈 

Works with single quotes... The parser does not seem to like nested double quotes 

![image](https://github.com/user-attachments/assets/e5fd6944-1bd0-40cb-977b-e6e62ec183a0)
