### PR TITLE
chore(ci): add input to allow specifying an environment

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.extensionName }}.zip
+          name: ${{ inputs.extensionName }}
           path: ${{ inputs.extensionName }}.zip

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -20,7 +20,12 @@ on:
         required: false
         type: string
         default: "."
-        
+      environment:
+        description: "The environment to use"
+        required: false
+        type: string
+        default: ""
+
     secrets:
       accountUser:
         required: true
@@ -31,6 +36,7 @@ on:
 jobs:
   Build:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
In order to e.g. apply rules to release jobs, I propose adding the possibility to define an environment. An empty environment is disregarded by GitHub, so this change won't influence existing workflows.