### PR TITLE
feat: add input poll_interval in downstreams with default 2m

### DIFF
--- a/downstream/action.yml
+++ b/downstream/action.yml
@@ -46,6 +46,9 @@ inputs:
     description: Timeout for the downstream
     required: false
     default: "30m"
+  poll_interval:
+    description: Poll interval for checking the status. By default 2 minutes
+    default: "2m"
 
 outputs:
   run_id:
@@ -105,4 +108,4 @@ runs:
         GH_TOKEN: ${{ inputs.token || steps.sts.outputs.token }}
         WORKFLOW: ${{ inputs.workflow }}
         REPO: ${{ inputs.repo }}
-      run: timeout "${{ inputs.timeout }}" ${GITHUB_ACTION_PATH}/wait.bash "$REPO" "$WORKFLOW" "${{ github.run_id }}"
+      run: timeout "${{ inputs.timeout }}" ${GITHUB_ACTION_PATH}/wait.bash "$REPO" "$WORKFLOW" "${{ github.run_id }}" "${{ inputs.poll_interval }}"

--- a/downstream/wait.bash
+++ b/downstream/wait.bash
@@ -2,6 +2,7 @@
 REPO=${1}
 WORKFLOW=${2}
 RUN_ID=${3}
+POLL_INTERVAL=${4}
 
 FILTER_DATE=$(TZ=UTC date -d "-5 minutes" "+%Y-%m-%dT%H:%M")
 MAX_ATTEMPTS=10
@@ -56,7 +57,7 @@ while true; do
         fi
     done
 
-    sleep 10
+    sleep ${POLL_INTERVAL}
 done
 
 url=https://github.com/${REPO}/actions/runs/${DOWNSTREAM_RUN_ID}


### PR DESCRIPTION
Currently value is 10 seconds, so we should decrease the api requests by a factor of 12