### PR TITLE
fix: fix build-zip action path in store-release action

### DIFF
--- a/store-release/action.yml
+++ b/store-release/action.yml
@@ -12,7 +12,7 @@ inputs:
   publishOnly:
     description: "Publish only to Shopware Store and dont create a tag"
     required: false
-    default: 'false'
+    default: "false"
   path:
     description: "Path to your bundle"
     required: false
@@ -29,12 +29,12 @@ inputs:
   skipCheckout:
     description: "Skip the checkout step"
     required: false
-    default: 'false'
+    default: "false"
 
 runs:
   using: "composite"
   steps:
-    - uses: shopware/build-zip@main
+    - uses: shopware/github-actions/build-zip@main
       with:
         extensionName: ${{ inputs.extensionName }}
         skipCheckout: ${{ inputs.skipCheckout }}


### PR DESCRIPTION
The path to the build-zip action is missing the "github-actions" repo name