### PR TITLE
fix: use `head_ref` in order not to fall back to the PR target branch

### DIFF
--- a/downstream/action.yml
+++ b/downstream/action.yml
@@ -91,7 +91,7 @@ runs:
           {
             "upstream": {
               "id": "${{ github.run_id }}",
-              "ref": "${{ github.ref }}",
+              "ref": "${{ github.head_ref || github.ref }}",
               "repo": "${{ github.repository }}",
               "github-token": "${{ github.token }}",
               "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Problem

In [this downstream pipeline](https://github.com/shopware/shopware/actions/runs/14376060221/job/40308655221?pr=7890) we're using the upstream data generated by the downstream action to determine the shopware version:

```
UPSTREAM_DATA: {
  "upstream": {
    "id": "14376060221",
    "ref": "refs/heads/6.6.x",
    "repo": "shopware/shopware",
    "github-token": "***",
    "url": "https://github.com/shopware/shopware/actions/runs/14376060221"
  },
  "env": "NIGHTLY="
  }
WORKFLOW: Downstream
REPO: shopware/SwagCommercial
REF: next-40170/stop-applying-prefix-for-synonyms-6.6.x
```

Since the source event was a pull_request event, we used the _base_ ref instead of the pull requests _head_ ref, resulting in a failing pipeline since the matching branch wasn't checked out.

## Solution

I'd propose to use the `head_ref` (only valid and present for pull request events) and fall back to `ref`.

From the [docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context):

`github.ref`:
> For workflows triggered by pull_request, this is the pull request merge branch

`github.head_ref`:
> The head_ref or source branch of the pull request in a workflow run. This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target.