### PR TITLE
Change to new major and LTS version in action.yml

### DIFF
--- a/versions/action.yml
+++ b/versions/action.yml
@@ -8,10 +8,10 @@ branding:
 inputs:
   major:
     description: Current major prefix like v6.6.
-    default: v6.6.
+    default: v6.7.
   lts-major:
     description: LTS major prefix like v6.5.
-    default: v6.5.
+    default: v6.6.
 
 outputs:
   first-version:


### PR DESCRIPTION
Because of the new major 6.7 we change now the LTS version to 6.6