### PR TITLE
feat: add ai-release-notes composite action

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A collection of reusable GitHub Actions and Workflows for Shopware extensions an
 
 | Action | Description | Link |
 |--------|-------------|------|
+| [ai-release-notes](ai-release-notes/) | Generates AI-powered release notes and creates a draft GitHub release | [README](ai-release-notes/README.md) |
 | [build-zip](build-zip/) | Builds the extension zip and validates it | [README](build-zip/README.md) |
 | [store-release](store-release/) | Builds the extension and uploads it to the Shopware Store | [README](store-release/README.md) |
 

--- a/ai-release-notes/README.md
+++ b/ai-release-notes/README.md
@@ -54,6 +54,8 @@ Override formatting, sections, and release settings.
           bold-features: "false"
           sections: "Breaking Changes,New Features,Improvements,Bug Fixes,Internal"
           collapse-types: "dependency,CI,refactor"
+          tag-pattern: "^v"
+          release-name: "{tag}"
           draft: "false"
 ```
 
@@ -87,6 +89,8 @@ Use the action as a pure notes generator — for example to post to Slack or app
 | `custom-prompt` | no | `""` | Completely override the system prompt (ignores all formatting inputs) |
 | `model` | no | `"gpt-4o"` | GitHub Models API model name |
 | `temperature` | no | `"0.4"` | AI temperature (`0.0` = deterministic, `1.0` = creative) |
+| `tag-pattern` | no | `"^v"` | Regex pattern to match tags when detecting the previous release |
+| `release-name` | no | `"Release {tag}"` | Release name template — use `{tag}` as placeholder for the tag name |
 | `draft` | no | `"true"` | Create the release as a draft |
 | `prerelease` | no | `"false"` | Mark the release as a prerelease |
 | `create-release` | no | `"true"` | Whether to create a GitHub release (`"false"` = only generate notes) |

--- a/ai-release-notes/README.md
+++ b/ai-release-notes/README.md
@@ -1,0 +1,136 @@
+# AI Release Notes
+
+Generate polished, AI-powered release notes from GitHub's auto-generated changelog and optionally create a draft GitHub release.
+
+The action compares the current tag with the previous one, fetches the raw changelog via the GitHub API, rewrites it using the [GitHub Models API](https://docs.github.com/en/github-models), and creates a draft release with the result.
+
+## Prerequisites
+
+The calling workflow must:
+
+1. **Check out the repository** with full history (`fetch-depth: 0`) so previous tags can be detected.
+2. **Grant permissions** for `contents: write` (to create releases) and `models: read` (to call the AI API).
+
+## Usage
+
+### Minimal Example
+
+Reproduces the default behaviour — no PR links, no authors, bold feature names, sections: *New Features, Improvements, Bug Fixes, Other*.
+
+```yaml
+name: AI Release Notes
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+  models: read
+
+jobs:
+  release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: shopware/github-actions/ai-release-notes@main
+        with:
+          product-name: "My Product"
+```
+
+### Customised Example
+
+Override formatting, sections, and release settings.
+
+```yaml
+      - uses: shopware/github-actions/ai-release-notes@main
+        with:
+          product-name: "Databus"
+          product-description: "A workflow execution engine written in Go"
+          include-pr-links: "true"
+          include-authors: "true"
+          bold-features: "false"
+          sections: "Breaking Changes,New Features,Improvements,Bug Fixes,Internal"
+          collapse-types: "dependency,CI,refactor"
+          draft: "false"
+```
+
+### Generate Notes Without Creating a Release
+
+Use the action as a pure notes generator — for example to post to Slack or append to a changelog file.
+
+```yaml
+      - uses: shopware/github-actions/ai-release-notes@main
+        id: notes
+        with:
+          product-name: "Nexus Contracts"
+          create-release: "false"
+
+      - name: Post to Slack
+        run: echo "${{ steps.notes.outputs.release-notes }}"
+```
+
+## Inputs
+
+| Input | Required | Default | Description |
+|---|---|---|---|
+| `product-name` | **yes** | — | Product name used in the AI prompt |
+| `product-description` | no | `""` | Optional product context for better AI output |
+| `bold-features` | no | `"true"` | Use **bold** for feature names in bullets |
+| `include-pr-links` | no | `"false"` | Include PR links in bullets |
+| `include-authors` | no | `"false"` | Include author attributions in bullets |
+| `sections` | no | `"New Features,Improvements,Bug Fixes,Other"` | Comma-separated list of sections in desired order |
+| `collapse-types` | no | `"dependency,translation,CI"` | Change types collapsed under the last section |
+| `additional-rules` | no | `""` | Extra rules appended to the default prompt |
+| `custom-prompt` | no | `""` | Completely override the system prompt (ignores all formatting inputs) |
+| `model` | no | `"gpt-4o"` | GitHub Models API model name |
+| `temperature` | no | `"0.4"` | AI temperature (`0.0` = deterministic, `1.0` = creative) |
+| `draft` | no | `"true"` | Create the release as a draft |
+| `prerelease` | no | `"false"` | Mark the release as a prerelease |
+| `create-release` | no | `"true"` | Whether to create a GitHub release (`"false"` = only generate notes) |
+| `github-token` | no | `${{ github.token }}` | GitHub token (needs `models:read` + `contents:write`) |
+
+## Outputs
+
+| Output | Description |
+|---|---|
+| `release-notes` | The AI-generated release notes (Markdown) |
+| `raw-notes` | The raw GitHub-generated changelog before AI rewrite |
+| `release-url` | URL of the created release (empty if `create-release` is `"false"`) |
+| `previous-tag` | The detected previous git tag |
+
+## How the Prompt Works
+
+By default, the action builds a system prompt dynamically from the inputs. The prompt instructs the AI to:
+
+- Group changes under the configured **sections** (omitting empty ones)
+- **Collapse** dependency bumps, translations, and CI changes under the last section
+- Optionally **bold** feature names, include/exclude **PR links** and **authors**
+- Start with a `## Release Notes — <tag>` heading
+- Keep the "Full Changelog" comparison link
+
+### Extending the Default Prompt
+
+Use `additional-rules` to add domain-specific instructions without replacing the entire prompt:
+
+```yaml
+        with:
+          product-name: "My API"
+          additional-rules: |
+            - Always mention the affected API endpoint in parentheses.
+            - Flag any breaking changes with a ⚠️ emoji.
+```
+
+### Full Prompt Override
+
+Use `custom-prompt` when you need complete control. All formatting inputs (`bold-features`, `include-pr-links`, etc.) are ignored when a custom prompt is set:
+
+```yaml
+        with:
+          product-name: "My Product"
+          custom-prompt: |
+            You are a changelog writer. Summarise the changes in 3 bullet points.
+            Be extremely concise. Output Markdown only.
+```

--- a/ai-release-notes/action.yml
+++ b/ai-release-notes/action.yml
@@ -1,0 +1,238 @@
+name: "AI Release Notes"
+description: "Generate AI-powered release notes from GitHub's auto-generated changelog and create a draft GitHub release"
+author: "shopware AG"
+branding:
+  color: "blue"
+  icon: "file-text"
+
+inputs:
+  product-name:
+    description: "Product name used in the AI prompt (e.g. 'Nexus Workflow Builder')"
+    required: true
+  product-description:
+    description: "Optional product context for better AI output"
+    required: false
+    default: ""
+  bold-features:
+    description: "Use bold formatting for feature names in bullets"
+    required: false
+    default: "true"
+  include-pr-links:
+    description: "Include PR links in the release notes bullets"
+    required: false
+    default: "false"
+  include-authors:
+    description: "Include author attributions in the release notes bullets"
+    required: false
+    default: "false"
+  sections:
+    description: "Comma-separated list of sections in desired order"
+    required: false
+    default: "New Features,Improvements,Bug Fixes,Other"
+  collapse-types:
+    description: "Change types to collapse under the last section (comma-separated)"
+    required: false
+    default: "dependency,translation,CI"
+  additional-rules:
+    description: "Extra rules appended to the default system prompt"
+    required: false
+    default: ""
+  custom-prompt:
+    description: "Completely override the default system prompt (ignores all formatting inputs)"
+    required: false
+    default: ""
+  model:
+    description: "GitHub Models API model name"
+    required: false
+    default: "gpt-4o"
+  temperature:
+    description: "AI model temperature (0.0 = deterministic, 1.0 = creative)"
+    required: false
+    default: "0.4"
+  draft:
+    description: "Create the release as a draft"
+    required: false
+    default: "true"
+  prerelease:
+    description: "Mark the release as a prerelease"
+    required: false
+    default: "false"
+  create-release:
+    description: "Whether to create a GitHub release (set to false to only generate notes)"
+    required: false
+    default: "true"
+  github-token:
+    description: "GitHub token with models:read and contents:write permissions"
+    required: false
+    default: "${{ github.token }}"
+
+outputs:
+  release-notes:
+    description: "The AI-generated release notes (Markdown)"
+    value: "${{ steps.ai-notes.outputs.notes }}"
+  raw-notes:
+    description: "The raw GitHub-generated changelog before AI rewrite"
+    value: "${{ steps.raw-notes.outputs.body }}"
+  release-url:
+    description: "URL of the created GitHub release (empty if create-release is false)"
+    value: "${{ steps.create-release.outputs.url }}"
+  previous-tag:
+    description: "The detected previous git tag"
+    value: "${{ steps.prev-tag.outputs.prev_tag }}"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Determine previous tag
+      id: prev-tag
+      shell: bash
+      run: |
+        CURRENT_TAG="${GITHUB_REF_NAME}"
+        PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v' | grep -v "^${CURRENT_TAG}$" | head -n 1)
+
+        if [[ -z "$PREV_TAG" ]]; then
+          echo "No previous tag found — this is the first release."
+          echo "prev_tag=" >> "$GITHUB_OUTPUT"
+        else
+          echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
+        fi
+
+        echo "Current tag: $CURRENT_TAG"
+        echo "Previous tag: ${PREV_TAG:-none}"
+
+    - name: Generate raw release notes via GitHub API
+      id: raw-notes
+      uses: actions/github-script@v8
+      with:
+        github-token: "${{ inputs.github-token }}"
+        script: |
+          const currentTag = process.env.GITHUB_REF_NAME;
+          const prevTag = '${{ steps.prev-tag.outputs.prev_tag }}';
+
+          const params = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            tag_name: currentTag,
+          };
+
+          if (prevTag) {
+            params.previous_tag_name = prevTag;
+          }
+
+          const { data } = await github.rest.repos.generateReleaseNotes(params);
+
+          core.setOutput('body', data.body);
+          core.setOutput('name', data.name);
+
+    - name: Rewrite release notes with AI
+      id: ai-notes
+      uses: actions/github-script@v8
+      env:
+        GITHUB_TOKEN: "${{ inputs.github-token }}"
+        RAW_NOTES: "${{ steps.raw-notes.outputs.body }}"
+      with:
+        script: |
+          const currentTag = process.env.GITHUB_REF_NAME;
+          const rawNotes = process.env.RAW_NOTES;
+
+          const customPrompt = `${{ inputs.custom-prompt }}`;
+          let systemPrompt;
+
+          if (customPrompt) {
+            systemPrompt = customPrompt;
+          } else {
+            const productName = `${{ inputs.product-name }}`;
+            const productDesc = `${{ inputs.product-description }}`;
+            const sections = `${{ inputs.sections }}`;
+            const collapseTypes = `${{ inputs.collapse-types }}`;
+            const boldFeatures = `${{ inputs.bold-features }}` === 'true';
+            const includePrLinks = `${{ inputs.include-pr-links }}` === 'true';
+            const includeAuthors = `${{ inputs.include-authors }}` === 'true';
+            const additionalRules = `${{ inputs.additional-rules }}`;
+            const lastSection = sections.split(',').pop().trim();
+
+            systemPrompt = `You are a release-notes editor for a SaaS product called ${productName}.`;
+
+            if (productDesc) {
+              systemPrompt += `\nProduct context: ${productDesc}`;
+            }
+
+            systemPrompt += `
+          You receive the auto-generated GitHub "What's Changed" list and rewrite it into polished,
+          user-friendly release notes grouped by category.
+
+          Rules:
+          - Use these sections (omit any that have no items): ${sections}.
+          - Each bullet should be concise but descriptive — translate commit-speak into product language.
+          - Collapse ${collapseTypes} changes into a single bullet each under "${lastSection}".`;
+
+            if (boldFeatures) {
+              systemPrompt += `\n- Use **bold** for feature names in bullets.`;
+            }
+            if (!includePrLinks) {
+              systemPrompt += `\n- Do NOT include PR links or PR numbers in the bullets.`;
+            }
+            if (!includeAuthors) {
+              systemPrompt += `\n- Do NOT include author attributions in the bullets.`;
+            }
+
+            systemPrompt += `
+          - Keep the "Full Changelog" comparison link at the bottom exactly as provided.
+          - Start with a heading: ## Release Notes — ${currentTag}
+          - Output clean Markdown, nothing else.`;
+
+            if (additionalRules) {
+              systemPrompt += `\n\nAdditional rules:\n${additionalRules}`;
+            }
+          }
+
+          const response = await fetch('https://models.inference.ai.azure.com/chat/completions', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
+            },
+            body: JSON.stringify({
+              model: '${{ inputs.model }}',
+              temperature: parseFloat('${{ inputs.temperature }}'),
+              messages: [
+                { role: 'system', content: systemPrompt },
+                { role: 'user', content: `Rewrite these auto-generated release notes:\n\n${rawNotes}` },
+              ],
+            }),
+          });
+
+          if (!response.ok) {
+            const errorBody = await response.text();
+            core.setFailed(`GitHub Models API error (${response.status}): ${errorBody}`);
+            return;
+          }
+
+          const result = await response.json();
+          const aiNotes = result.choices[0].message.content;
+
+          core.setOutput('notes', aiNotes);
+
+    - name: Create GitHub release
+      id: create-release
+      if: inputs.create-release == 'true'
+      uses: actions/github-script@v8
+      env:
+        AI_NOTES: "${{ steps.ai-notes.outputs.notes }}"
+      with:
+        github-token: "${{ inputs.github-token }}"
+        script: |
+          const tag = process.env.GITHUB_REF_NAME;
+
+          const release = await github.rest.repos.createRelease({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            tag_name: tag,
+            name: `Release ${tag}`,
+            body: process.env.AI_NOTES,
+            draft: ${{ inputs.draft }},
+            prerelease: ${{ inputs.prerelease }},
+          });
+
+          core.setOutput('url', release.data.html_url);
+          core.notice(`Release created: ${release.data.html_url}`);

--- a/ai-release-notes/action.yml
+++ b/ai-release-notes/action.yml
@@ -49,6 +49,14 @@ inputs:
     description: "AI model temperature (0.0 = deterministic, 1.0 = creative)"
     required: false
     default: "0.4"
+  tag-pattern:
+    description: "Regex pattern to match tags when detecting the previous release (e.g. '^v', '^release-')"
+    required: false
+    default: "^v"
+  release-name:
+    description: "Release name template — use {tag} as placeholder for the tag name"
+    required: false
+    default: "Release {tag}"
   draft:
     description: "Create the release as a draft"
     required: false
@@ -86,9 +94,11 @@ runs:
     - name: Determine previous tag
       id: prev-tag
       shell: bash
+      env:
+        TAG_PATTERN: "${{ inputs.tag-pattern }}"
       run: |
         CURRENT_TAG="${GITHUB_REF_NAME}"
-        PREV_TAG=$(git tag --sort=-v:refname | grep -E '^v' | grep -v "^${CURRENT_TAG}$" | head -n 1)
+        PREV_TAG=$(git tag --sort=-v:refname | grep -E "${TAG_PATTERN}" | grep -v "^${CURRENT_TAG}$" | head -n 1)
 
         if [[ -z "$PREV_TAG" ]]; then
           echo "No previous tag found — this is the first release."
@@ -103,11 +113,13 @@ runs:
     - name: Generate raw release notes via GitHub API
       id: raw-notes
       uses: actions/github-script@v8
+      env:
+        INPUT_PREV_TAG: "${{ steps.prev-tag.outputs.prev_tag }}"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |
           const currentTag = process.env.GITHUB_REF_NAME;
-          const prevTag = '${{ steps.prev-tag.outputs.prev_tag }}';
+          const prevTag = process.env.INPUT_PREV_TAG;
 
           const params = {
             owner: context.repo.owner,
@@ -130,60 +142,78 @@ runs:
       env:
         GITHUB_TOKEN: "${{ inputs.github-token }}"
         RAW_NOTES: "${{ steps.raw-notes.outputs.body }}"
+        INPUT_PRODUCT_NAME: "${{ inputs.product-name }}"
+        INPUT_PRODUCT_DESCRIPTION: "${{ inputs.product-description }}"
+        INPUT_SECTIONS: "${{ inputs.sections }}"
+        INPUT_COLLAPSE_TYPES: "${{ inputs.collapse-types }}"
+        INPUT_BOLD_FEATURES: "${{ inputs.bold-features }}"
+        INPUT_INCLUDE_PR_LINKS: "${{ inputs.include-pr-links }}"
+        INPUT_INCLUDE_AUTHORS: "${{ inputs.include-authors }}"
+        INPUT_ADDITIONAL_RULES: "${{ inputs.additional-rules }}"
+        INPUT_CUSTOM_PROMPT: "${{ inputs.custom-prompt }}"
+        INPUT_MODEL: "${{ inputs.model }}"
+        INPUT_TEMPERATURE: "${{ inputs.temperature }}"
       with:
         script: |
           const currentTag = process.env.GITHUB_REF_NAME;
           const rawNotes = process.env.RAW_NOTES;
+          const customPrompt = process.env.INPUT_CUSTOM_PROMPT;
 
-          const customPrompt = `${{ inputs.custom-prompt }}`;
           let systemPrompt;
 
           if (customPrompt) {
             systemPrompt = customPrompt;
           } else {
-            const productName = `${{ inputs.product-name }}`;
-            const productDesc = `${{ inputs.product-description }}`;
-            const sections = `${{ inputs.sections }}`;
-            const collapseTypes = `${{ inputs.collapse-types }}`;
-            const boldFeatures = `${{ inputs.bold-features }}` === 'true';
-            const includePrLinks = `${{ inputs.include-pr-links }}` === 'true';
-            const includeAuthors = `${{ inputs.include-authors }}` === 'true';
-            const additionalRules = `${{ inputs.additional-rules }}`;
+            const productName = process.env.INPUT_PRODUCT_NAME;
+            const productDesc = process.env.INPUT_PRODUCT_DESCRIPTION;
+            const sections = process.env.INPUT_SECTIONS;
+            const collapseTypes = process.env.INPUT_COLLAPSE_TYPES;
+            const boldFeatures = process.env.INPUT_BOLD_FEATURES === 'true';
+            const includePrLinks = process.env.INPUT_INCLUDE_PR_LINKS === 'true';
+            const includeAuthors = process.env.INPUT_INCLUDE_AUTHORS === 'true';
+            const additionalRules = process.env.INPUT_ADDITIONAL_RULES;
             const lastSection = sections.split(',').pop().trim();
 
-            systemPrompt = `You are a release-notes editor for a SaaS product called ${productName}.`;
+            const lines = [
+              `You are a release-notes editor for a SaaS product called ${productName}.`,
+            ];
 
             if (productDesc) {
-              systemPrompt += `\nProduct context: ${productDesc}`;
+              lines.push(`Product context: ${productDesc}`);
             }
 
-            systemPrompt += `
-          You receive the auto-generated GitHub "What's Changed" list and rewrite it into polished,
-          user-friendly release notes grouped by category.
-
-          Rules:
-          - Use these sections (omit any that have no items): ${sections}.
-          - Each bullet should be concise but descriptive — translate commit-speak into product language.
-          - Collapse ${collapseTypes} changes into a single bullet each under "${lastSection}".`;
+            lines.push(
+              'You receive the auto-generated GitHub "What\'s Changed" list and rewrite it into polished, user-friendly release notes grouped by category.',
+              '',
+              'Rules:',
+              `- Use these sections (omit any that have no items): ${sections}.`,
+              '- Each bullet should be concise but descriptive — translate commit-speak into product language.',
+              `- Collapse ${collapseTypes} changes into a single bullet each under "${lastSection}".`,
+            );
 
             if (boldFeatures) {
-              systemPrompt += `\n- Use **bold** for feature names in bullets.`;
-            }
-            if (!includePrLinks) {
-              systemPrompt += `\n- Do NOT include PR links or PR numbers in the bullets.`;
-            }
-            if (!includeAuthors) {
-              systemPrompt += `\n- Do NOT include author attributions in the bullets.`;
+              lines.push('- Use **bold** for feature names in bullets.');
             }
 
-            systemPrompt += `
-          - Keep the "Full Changelog" comparison link at the bottom exactly as provided.
-          - Start with a heading: ## Release Notes — ${currentTag}
-          - Output clean Markdown, nothing else.`;
+            if (!includePrLinks) {
+              lines.push('- Do NOT include PR links or PR numbers in the bullets.');
+            }
+
+            if (!includeAuthors) {
+              lines.push('- Do NOT include author attributions in the bullets.');
+            }
+
+            lines.push(
+              '- Keep the "Full Changelog" comparison link at the bottom exactly as provided.',
+              `- Start with a heading: ## Release Notes — ${currentTag}`,
+              '- Output clean Markdown, nothing else.',
+            );
 
             if (additionalRules) {
-              systemPrompt += `\n\nAdditional rules:\n${additionalRules}`;
+              lines.push('', 'Additional rules:', additionalRules);
             }
+
+            systemPrompt = lines.join('\n');
           }
 
           const response = await fetch('https://models.inference.ai.azure.com/chat/completions', {
@@ -193,8 +223,8 @@ runs:
               'Authorization': `Bearer ${process.env.GITHUB_TOKEN}`,
             },
             body: JSON.stringify({
-              model: '${{ inputs.model }}',
-              temperature: parseFloat('${{ inputs.temperature }}'),
+              model: process.env.INPUT_MODEL,
+              temperature: parseFloat(process.env.INPUT_TEMPERATURE),
               messages: [
                 { role: 'system', content: systemPrompt },
                 { role: 'user', content: `Rewrite these auto-generated release notes:\n\n${rawNotes}` },
@@ -209,8 +239,13 @@ runs:
           }
 
           const result = await response.json();
-          const aiNotes = result.choices[0].message.content;
 
+          if (!result.choices?.length) {
+            core.setFailed(`Unexpected API response: ${JSON.stringify(result)}`);
+            return;
+          }
+
+          const aiNotes = result.choices[0].message.content;
           core.setOutput('notes', aiNotes);
 
     - name: Create GitHub release
@@ -219,19 +254,25 @@ runs:
       uses: actions/github-script@v8
       env:
         AI_NOTES: "${{ steps.ai-notes.outputs.notes }}"
+        INPUT_RELEASE_NAME: "${{ inputs.release-name }}"
+        INPUT_DRAFT: "${{ inputs.draft }}"
+        INPUT_PRERELEASE: "${{ inputs.prerelease }}"
       with:
         github-token: "${{ inputs.github-token }}"
         script: |
           const tag = process.env.GITHUB_REF_NAME;
+          const releaseName = process.env.INPUT_RELEASE_NAME.replace('{tag}', tag);
+          const isDraft = process.env.INPUT_DRAFT === 'true';
+          const isPrerelease = process.env.INPUT_PRERELEASE === 'true';
 
           const release = await github.rest.repos.createRelease({
             owner: context.repo.owner,
             repo: context.repo.repo,
             tag_name: tag,
-            name: `Release ${tag}`,
+            name: releaseName,
             body: process.env.AI_NOTES,
-            draft: ${{ inputs.draft }},
-            prerelease: ${{ inputs.prerelease }},
+            draft: isDraft,
+            prerelease: isPrerelease,
           });
 
           core.setOutput('url', release.data.html_url);


### PR DESCRIPTION
## Summary

- Adds a new `ai-release-notes` composite action that generates AI-powered release notes and creates draft GitHub releases
- Extracts and generalises the inline workflow logic from `nexus-workflow-builder` into a reusable, configurable action
- All formatting options (bold features, PR links, authors, sections, collapse types) are configurable via inputs with sensible defaults

## Context

Ref: shopware/pipe-fiction#477

The AI release notes logic currently lives only in `nexus-workflow-builder` as a 139-line inline workflow. Other repos (databus, nexus-contracts, nexus-service) cannot reuse it without copy-pasting.

This action makes it available to any repo via:

```yaml
- uses: shopware/github-actions/ai-release-notes@main
  with:
    product-name: "My Product"
```

## What's included

| File | Purpose |
|---|---|
| `ai-release-notes/action.yml` | Composite action with 4 steps: detect previous tag, generate raw notes, AI rewrite, create release |
| `ai-release-notes/README.md` | Documentation with inputs, outputs, and usage examples (minimal, customised, notes-only) |
| `README.md` | Updated root README with new action in the Build & Release table |

## Default behaviour

With only `product-name` set, the action reproduces the current nexus-workflow-builder behaviour:
- Sections: New Features, Improvements, Bug Fixes, Other
- Bold feature names
- No PR links, no author attributions
- Dependency/translation/CI changes collapsed under "Other"
- Draft release created

## Test plan

- [ ] Push a `v*` tag to a test repo using the action and verify the draft release is created with expected formatting
- [ ] Test with `create-release: "false"` and verify notes are available via outputs
- [ ] Test with custom inputs (`include-pr-links: "true"`, different sections) and verify prompt changes
- [ ] Wire `nexus-workflow-builder` to use this action and compare output with previous inline workflow


Made with [Cursor](https://cursor.com)