### PR TITLE
fix: install extension with dependencies over composer

### DIFF
--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -247,7 +247,7 @@ runs:
     - name: Install extension with Composer
       if: ${{ env.IS_PLUGIN == 'true' }}
       shell: bash
-      run: composer require $(composer -d custom/plugins/${{ inputs.extensionName }} config name)
+      run: composer require $(composer -d custom/plugins/${{ inputs.extensionName }} config name) --with-dependencies
 
     - name: Refresh Plugins
       if: ${{ inputs.install == 'true' && env.IS_PLUGIN == 'true' }}


### PR DESCRIPTION
Without the flag composer tries to install the extension in the current set of downloaded packages, which might fail because when setting up shopware a newer package could already have been installed that is not compatible with this extension

By providing the `--with-dependencies` flag composer tries to find an installable set of versions also for dependencies of the plugin and it downgrades or upgrades those dependencies as needed

this fixes the current issue in the rufus pipelines: https://github.com/shopware/Rufus/actions/runs/23234653710/job/67535564727