### PR TITLE
feat: add clientId/clientSecret authentication to store-release action

### DIFF
--- a/store-release/README.md
+++ b/store-release/README.md
@@ -17,16 +17,20 @@ Builds the extension and uploads a zip of it to the Shopware Store.
 | `extensionName` | Your extension name | Yes | - |
 | `publishOnly` | Publish only to Shopware Store and don't create a tag | No | `false` |
 | `path` | Path to your bundle | No | `.` |
-| `accountUser` | Your Shopware account user | Yes | - |
-| `accountPassword` | Your Shopware account password | Yes | - |
+| `clientId` | Your Shopware account client ID for API authentication | No* | - |
+| `clientSecret` | Your Shopware account client secret for API authentication | No* | - |
+| `accountUser` | Your Shopware account user (deprecated) | No* | - |
+| `accountPassword` | Your Shopware account password (deprecated) | No* | - |
 | `ghToken` | GitHub token | Yes | - |
 | `skipCheckout` | Skip the checkout step | No | `false` |
 | `disableGit` | Use the source folder as it is | No | `false` |
 | `updateInfo` | Update extension information on the Shopware Store plugin page | No | `false` |
 
+*\* Either `clientId`/`clientSecret` or `accountUser`/`accountPassword` must be provided.*
+
 ## Usage
 
-### Basic usage
+### Basic usage (client credentials)
 
 ```yaml
 name: Release to Store
@@ -39,7 +43,24 @@ jobs:
     uses: shopware/github-actions/store-release@main
     with:
       extensionName: MyExtensionName
-    secrets:
+      clientId: ${{ secrets.SHOPWARE_CLIENT_ID }}
+      clientSecret: ${{ secrets.SHOPWARE_CLIENT_SECRET }}
+      ghToken: ${{ secrets.GITHUB_TOKEN }}
+```
+
+### Basic usage (legacy username/password)
+
+```yaml
+name: Release to Store
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    uses: shopware/github-actions/store-release@main
+    with:
+      extensionName: MyExtensionName
       accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
       accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
       ghToken: ${{ secrets.GITHUB_TOKEN }}
@@ -54,9 +75,8 @@ jobs:
     with:
       extensionName: MyExtensionName
       publishOnly: 'true'
-    secrets:
-      accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
-      accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
+      clientId: ${{ secrets.SHOPWARE_CLIENT_ID }}
+      clientSecret: ${{ secrets.SHOPWARE_CLIENT_SECRET }}
       ghToken: ${{ secrets.GITHUB_TOKEN }}
 ```
 
@@ -69,15 +89,14 @@ jobs:
     with:
       extensionName: MyExtensionName
       updateInfo: 'true'
-    secrets:
-      accountUser: ${{ secrets.SHOPWARE_ACCOUNT_USER }}
-      accountPassword: ${{ secrets.SHOPWARE_ACCOUNT_PASSWORD }}
+      clientId: ${{ secrets.SHOPWARE_CLIENT_ID }}
+      clientSecret: ${{ secrets.SHOPWARE_CLIENT_SECRET }}
       ghToken: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 ## Requirements
 
-- Shopware account credentials must be stored as secrets:
-  - `SHOPWARE_ACCOUNT_USER`
-  - `SHOPWARE_ACCOUNT_PASSWORD`
+- Shopware account credentials must be stored as secrets. Either:
+  - `SHOPWARE_CLIENT_ID` and `SHOPWARE_CLIENT_SECRET` (recommended, generate at [Shopware Account](https://account.shopware.com/producer/development))
+  - `SHOPWARE_ACCOUNT_USER` and `SHOPWARE_ACCOUNT_PASSWORD` (deprecated)
 - GitHub token with `repo` permissions

--- a/store-release/action.yml
+++ b/store-release/action.yml
@@ -18,11 +18,17 @@ inputs:
     required: false
     default: "."
   accountUser:
-    description: "Your Shopware account user"
-    required: true
+    description: "Your Shopware account user (deprecated, use clientId/clientSecret instead)"
+    required: false
   accountPassword:
-    description: "Your Shopware account password"
-    required: true
+    description: "Your Shopware account password (deprecated, use clientId/clientSecret instead)"
+    required: false
+  clientId:
+    description: "Your Shopware account client ID for API authentication"
+    required: false
+  clientSecret:
+    description: "Your Shopware account client secret for API authentication"
+    required: false
   ghToken:
     description: "GitHub token"
     required: true
@@ -48,6 +54,11 @@ runs:
         skipCheckout: ${{ inputs.skipCheckout }}
         disableGit: ${{ inputs.disableGit }}
 
+    - name: Check for deprecated authentication
+      shell: bash
+      if: inputs.accountUser != ''
+      run: echo "::warning::The 'accountUser' and 'accountPassword' inputs are deprecated. Please use 'clientId' and 'clientSecret' instead. Generate credentials at https://account.shopware.com/producer/development"
+
     - name: Get version
       shell: bash
       run: |
@@ -69,6 +80,8 @@ runs:
         GITHUB_TOKEN: ${{ inputs.ghToken }}
         SHOPWARE_CLI_ACCOUNT_EMAIL: ${{ inputs.accountUser }}
         SHOPWARE_CLI_ACCOUNT_PASSWORD: ${{ inputs.accountPassword }}
+        SHOPWARE_CLI_ACCOUNT_CLIENT_ID: ${{ inputs.clientId }}
+        SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET: ${{ inputs.clientSecret }}
     - name: Update Extension Info
       shell: bash
       if: inputs.updateInfo == 'true'
@@ -77,6 +90,8 @@ runs:
         GITHUB_TOKEN: ${{ inputs.ghToken }}
         SHOPWARE_CLI_ACCOUNT_EMAIL: ${{ inputs.accountUser }}
         SHOPWARE_CLI_ACCOUNT_PASSWORD: ${{ inputs.accountPassword }}
+        SHOPWARE_CLI_ACCOUNT_CLIENT_ID: ${{ inputs.clientId }}
+        SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET: ${{ inputs.clientSecret }}
     - name: Extract Changelog
       shell: bash
       if: steps.checkTag.outputs.exists != 'true' && inputs.publishOnly == 'false'


### PR DESCRIPTION
## Summary

- Add new `clientId` and `clientSecret` inputs for API-based Shopware account authentication
- Deprecate legacy `accountUser` and `accountPassword` inputs (kept for backward compatibility with a deprecation warning)
- Pass new env vars `SHOPWARE_CLI_ACCOUNT_CLIENT_ID` and `SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET` to store-release and update-info steps
- Update README with new client credentials usage example, deprecation notice, and corrected YAML syntax

## Test plan

- [ ] Verify action works with `clientId`/`clientSecret` inputs
- [ ] Verify backward compatibility with deprecated `accountUser`/`accountPassword` inputs
- [ ] Verify deprecation warning is shown when legacy inputs are used
- [ ] Verify action fails with helpful error when neither auth method is provided