### PR TITLE
Update store workflow to use client credentials

### DIFF
--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -27,9 +27,9 @@ on:
         default: ""
 
     secrets:
-      accountUser:
+      clientId:
         required: true
-      accountPassword:
+      clientSecret:
         required: true
       ghToken:
         required: true
@@ -74,8 +74,8 @@ jobs:
         run: shopware-cli account producer extension upload $(pwd)/${{ inputs.extensionName }}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.ghToken }}
-          SHOPWARE_CLI_ACCOUNT_EMAIL: ${{ secrets.accountUser }}
-          SHOPWARE_CLI_ACCOUNT_PASSWORD: ${{ secrets.accountPassword }}
+          SHOPWARE_CLI_ACCOUNT_CLIENT_ID: ${{ secrets.clientId }}
+          SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET: ${{ secrets.clientSecret }}
       - name: Extract Changelog
         if: steps.checkTag.outputs.exists != 'true' && inputs.publishOnly == false
         run: shopware-cli extension get-changelog $(pwd)/${{ inputs.extensionName }}.zip > /tmp/changelog.txt


### PR DESCRIPTION
## Summary

- Migrates the store-release reusable workflow from account user/password authentication to client ID/secret credentials
- Renames `workflow_call` secrets from `accountUser`/`accountPassword` to `clientId`/`clientSecret`
- Updates env vars from `SHOPWARE_CLI_ACCOUNT_EMAIL`/`SHOPWARE_CLI_ACCOUNT_PASSWORD` to `SHOPWARE_CLI_ACCOUNT_CLIENT_ID`/`SHOPWARE_CLI_ACCOUNT_CLIENT_SECRET`

## Breaking Change

Callers of this reusable workflow must update their secret references:

```yaml
# Before
secrets:
  accountUser: ${{ secrets.ACCOUNT_USER }}
  accountPassword: ${{ secrets.ACCOUNT_PASSWORD }}

# After
secrets:
  clientId: ${{ secrets.CLIENT_ID }}
  clientSecret: ${{ secrets.CLIENT_SECRET }}
```