### PR TITLE
fix: allow insecure versions in phpstan, e2e and phpunit workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -71,6 +71,7 @@ jobs:
           env: e2e
           install-storefront: true
           install-admin: true
+          allow-insecure-versions: true
       - name: Clone Extension
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -59,6 +59,7 @@ jobs:
           php-version: 8.2
           env: prod
           install: "true"
+          allow-insecure-versions: true
       - name: Clone Extension
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -79,6 +79,7 @@ jobs:
           mysql-version: ${{ inputs.mysqlVersion }}
           composer-root-version: ${{ inputs.composerRootVersion }}
           php-extensions: pcov
+          allow-insecure-versions: true
       - name: Clone Extension
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Insecure versions should be allowed in phpstan, e2e and phpunit workflows.
For example, we can't run phpunit tests with shopware version 6.7.0.0 because of symfony security advisories.