### PR TITLE
feat: improve downstream identification

### DIFF
--- a/downstream/action.yml
+++ b/downstream/action.yml
@@ -53,10 +53,10 @@ inputs:
 outputs:
   run_id:
     description: The run id of the downstream workflow
-    value: "${{ steps.wait.downstream_run_id }}"
+    value: "${{ steps.trigger.outputs.run_id }}"
   run_url:
     description: The api url of the downstream workflow
-    value: "${{ steps.wait.downstream_run_url }}"
+    value: "${{ steps.trigger.outputs.run_url }}"
 
 runs:
   using: "composite"
@@ -85,6 +85,7 @@ runs:
 
     - name: Trigger Downstream
       shell: bash
+      id: trigger
       env:
         GH_TOKEN: ${{ inputs.token || steps.sts.outputs.token }}
         UPSTREAM_DATA: |
@@ -102,12 +103,14 @@ runs:
         WORKFLOW: ${{ inputs.workflow }}
         REPO: ${{ inputs.repo }}
         REF: ${{ steps.version.outputs.shopware-version || inputs.ref }}
-      run: gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$REF" -f upstream_data="$UPSTREAM_DATA"
+      run: |
+        run_url=$(gh workflow run "$WORKFLOW" --repo "$REPO" --ref "$REF" -f upstream_data="$UPSTREAM_DATA")
+        echo "run_url=${run_url}" >> "$GITHUB_OUTPUT"
+        echo "run_id=$(basename "$run_url")" >> "$GITHUB_OUTPUT"
     - name: Wait for conclusion
       shell: bash
       id: wait
       env:
         GH_TOKEN: ${{ inputs.token || steps.sts.outputs.token }}
-        WORKFLOW: ${{ inputs.workflow }}
         REPO: ${{ inputs.repo }}
-      run: timeout "${{ inputs.timeout }}" ${GITHUB_ACTION_PATH}/wait.bash "$REPO" "$WORKFLOW" "${{ github.run_id }}" "${{ inputs.poll_interval }}"
+      run: timeout "${{ inputs.timeout }}" ${GITHUB_ACTION_PATH}/wait.bash "$REPO" "${{ inputs.poll_interval }}" "${{ steps.trigger.outputs.run_url }}"

--- a/downstream/wait.bash
+++ b/downstream/wait.bash
@@ -1,17 +1,9 @@
 #!/usr/bin/env bash
 REPO=${1}
-WORKFLOW=${2}
-RUN_ID=${3}
-POLL_INTERVAL=${4}
+POLL_INTERVAL=${2}
+DOWNSTREAM_RUN_URL=${3}
 
-# TODO: Remove old logic when no branches are outdated
-NEW_LOGIC=${NEW_LOGIC:-0}
-
-FILTER_DATE=$(TZ=UTC date -d "-5 minutes" "+%Y-%m-%dT%H:%M")
-MAX_ATTEMPTS=10
-ATTEMPT=1
-
-DOWNSTREAM_RUN_ID=invalid
+DOWNSTREAM_RUN_ID=$(basename "$DOWNSTREAM_RUN_URL")
 
 trap on_sigterm SIGTERM
 
@@ -21,65 +13,11 @@ on_sigterm() {
 }
 
 fail() {
-    if [[ -z "${DOWNSTREAM_RUN_ID}" || ! "${DOWNSTREAM_RUN_ID}" =~ ^[0-9]+$ ]]; then
-        echo "Failed to find run id in downstream"
-        exit 1
-    fi
-
-    echo "Please check https://github.com/${REPO}/actions/runs/${DOWNSTREAM_RUN_ID} for further information."
+    echo "Please check ${DOWNSTREAM_RUN_URL} for further information."
     exit 1
 }
 
-get_run_ids() {
-    gh run list --workflow="${WORKFLOW}" --event workflow_dispatch --repo "${REPO}" --created ">=${FILTER_DATE}" --json databaseId | jq '.[] | .databaseId'
-}
-
-find_connect_step_job_id() {
-    # TODO: Remove old logic when no branches are outdated
-    if [[ ${NEW_LOGIC} -ne 1 ]]; then
-        gh run view "$1" --repo "$REPO" --json jobs |
-            jq '.jobs[] | select(.steps[] | .name | contains("upstream-connect")) | .databaseId'
-        return
-    fi
-    gh run view "$1" --repo "$REPO" --json jobs |
-        jq --arg run_id "$RUN_ID" '.jobs[] | select(.name | contains($run_id)) | .databaseId'
-}
-
-while true; do
-    if [[ ${NEW_LOGIC} -eq 1 && ${ATTEMPT} -gt ${MAX_ATTEMPTS} ]]; then
-        fail
-    fi
-    echo "Trying to get run id from downstream. Attempt: ${ATTEMPT}"
-    ATTEMPT=$((ATTEMPT + 1))
-
-    readarray -t RUNS < <(get_run_ids)
-
-    echo "Found the following runs:"
-    echo "${RUNS[@]}"
-
-    for RUN in "${RUNS[@]}"; do
-        job_id=$(find_connect_step_job_id "$RUN")
-        echo "$job_id"
-
-        if [[ -n $job_id ]]; then
-            # TODO: Remove old logic when no branches are outdated
-            if [[ ${NEW_LOGIC} -ne 1 ]] && ! gh run view "$RUN" --repo "$REPO" --log -j "$job_id" | grep -q "$RUN_ID"; then
-                continue
-            fi
-            # Break out of for and until loop
-            DOWNSTREAM_RUN_ID=${RUN}
-            break 2
-        fi
-    done
-
-    sleep "${POLL_INTERVAL}"
-done
-
-url=https://github.com/${REPO}/actions/runs/${DOWNSTREAM_RUN_ID}
-echo "Downstream workflow: $url"
-
-echo "downstream_run_id=${DOWNSTREAM_RUN_ID}" >>"$GITHUB_OUTPUT"
-echo "downstream_run_url=${url}" >>"$GITHUB_OUTPUT"
+echo "Downstream workflow: ${DOWNSTREAM_RUN_URL}"
 
 ATTEMPT=1
 


### PR DESCRIPTION
The GitHub CLI now returns the URL of the triggered workflow run when calling `gh workflow run`. We capture this URL in the trigger step and pass it directly to `wait.bash`.

This removes the previous heuristic search - listing recent workflow dispatches filtered by date and matching them by job step name or log content - along with the `NEW_LOGIC` flag and its retry loop that guarded it. The script now goes straight to polling the correct run for its completion status.
