### PR TITLE
fix(downstream): dont persist credentials

### DIFF
--- a/downstream/action.yml
+++ b/downstream/action.yml
@@ -63,6 +63,8 @@ runs:
   steps:
     - name: Checkout
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - uses: shopware/octo-sts-action@main
       if: ${{ ! inputs.token }}
       id: sts


### PR DESCRIPTION
Github's `actions/checkout` now persist the credentials different. But we don't need the original permissions in git as we override them directly, so we can disable it.