### PR TITLE
fix: version logic

### DIFF
--- a/versions/print_versions.bash
+++ b/versions/print_versions.bash
@@ -18,16 +18,15 @@ get_tags_without_rc() {
 }
 
 get_next_minor_and_patch() {
-    DAY_OF_WEEK=$(date --utc +%u) # 1=Monday, 7=Sunday
-    DAY_NEXT_MONDAY=$(date --utc --date="+$((8 - ${DAY_OF_WEEK})) days" +%d)
-
     version=${1}
     local max_tag=$(get_tags_without_rc | grep -E "^${version}" | tail -n 1)
     if [[ -z $max_tag ]]; then
         max_tag=$(get_tags | grep -E "^${version}" | tail -n 1)
     fi
     IFS='.' read -r -a parts <<<"${max_tag}"
-    if [ "$DAY_NEXT_MONDAY" -lt 7 ]; then
+
+    local next_release_branch="${parts[0]#v}.${parts[1]}.$((${parts[2]} + 1)).x"
+    if gh api "repos/shopware/shopware/branches/${next_release_branch}" --silent 2>/dev/null; then
         echo "NEXT_MINOR=${parts[0]}.${parts[1]}.$((${parts[2]} + 2)).0"
     else
         echo "NEXT_MINOR=${parts[0]}.${parts[1]}.$((${parts[2]} + 1)).0"


### PR DESCRIPTION
Latest tag is e.g. v6.7.10.0.

- 6.7.11.x branch doesn't exist → 6.7.11.0 is still open for development → NEXT_MINOR=6.7.11.0
- 6.7.11.x branch exists → 6.7.11.0 is frozen for release → trunk PRs should target the version after → NEXT_MINOR=6.7.12.0