### PR TITLE
fix: remove example from pull_request description of update-saas-refs

### DIFF
--- a/update-saas-refs/action.yml
+++ b/update-saas-refs/action.yml
@@ -9,7 +9,7 @@ inputs:
   pull_request:
     required: true
     default: ${{ github.event.pull_request }}
-    description: The pull request that triggered the update, e.g. ${{ github.event.pull_request }}
+    description: The pull request that triggered the update
   target-branch:
     required: false
     default: ${{ github.base_ref }}


### PR DESCRIPTION
It seems like, Github tries to resolve the `${{ github.event.pull_request }}` in the description.
```
Error: shopware/github-actions/main/update-saas-refs/action.yml (Line: 12, Col: 18): Unrecognized named-value: 'github'. Located at position 1 within expression: github.event.pull_request
```