### PR TITLE
feat(plugin-lifecycle): add plugin install/uninstall/reinstall lifecycle action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
               with:
                 php-version: "8.3"
                 extensions: pdo_mysql

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,3 +122,48 @@ jobs:
                     echo "next-minor looks wrong: '${NEXT_MINOR}'"
                     exit 1
                 fi
+
+    plugin-lifecycle-assert-tables:
+        runs-on: ubuntu-latest
+        services:
+            mysql:
+                image: mysql:8.0
+                env:
+                    MYSQL_ROOT_PASSWORD: root
+                    MYSQL_DATABASE: shopware
+                ports:
+                    - 3306:3306
+                options: >-
+                    --health-cmd="mysqladmin ping -proot"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=10
+        env:
+            DATABASE_URL: mysql://root:root@127.0.0.1:3306/shopware
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                php-version: "8.3"
+                extensions: pdo_mysql
+            - name: Create a fixture table
+              run: |
+                php -r '$p=parse_url(getenv("DATABASE_URL")); $pdo=new PDO(sprintf("mysql:host=%s;port=%d;dbname=%s",$p["host"],$p["port"],ltrim($p["path"],"/")),$p["user"],$p["pass"]); $pdo->exec("CREATE TABLE existing_table (id INT)");'
+            - name: present + existing table -> passes
+              run: php plugin-lifecycle/assert-tables.php present existing_table
+            - name: absent + existing table -> must fail
+              run: |
+                if php plugin-lifecycle/assert-tables.php absent existing_table; then
+                    echo "expected a non-zero exit but the script passed"; exit 1
+                fi
+            - name: present + missing table -> must fail
+              run: |
+                if php plugin-lifecycle/assert-tables.php present missing_table; then
+                    echo "expected a non-zero exit but the script passed"; exit 1
+                fi
+            - name: absent + missing table -> passes
+              run: php plugin-lifecycle/assert-tables.php absent missing_table
+            - name: no tables -> passes (no-op)
+              run: php plugin-lifecycle/assert-tables.php absent

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A collection of reusable GitHub Actions and Workflows for Shopware extensions an
 |--------|-------------|------|
 | [admin-jest](admin-jest/) | Runs administration Jest tests | [README](admin-jest/README.md) |
 | [phpunit](phpunit/) | Runs PHPUnit tests for Shopware extensions | [README](phpunit/README.md) |
+| [plugin-lifecycle](plugin-lifecycle/) | Validates a plugin's install/uninstall/reinstall lifecycle and DAL wiring | [README](plugin-lifecycle/README.md) |
 
 ### Build & Release
 

--- a/plugin-lifecycle/README.md
+++ b/plugin-lifecycle/README.md
@@ -9,16 +9,17 @@ actually installed on that version.
 
 ## What it does
 
-1. `plugin:refresh`, then `plugin:install --activate` — boots the container, so a plugin that does not compile against the installed Shopware release fails here
-2. `dal:validate` — validates every registered definition and its associations against the real database schema
-3. `plugin:uninstall`, then asserts the configured tables are gone (clean uninstall)
-4. `plugin:install --activate` again, asserts the configured tables are back, and re-runs `dal:validate` (working reinstall)
+1. `dal:validate` — validates every registered definition and its associations against the real database schema
+2. `plugin:uninstall`, then asserts the configured tables are gone (clean uninstall)
+3. `plugin:install --activate`, asserts the configured tables are back, and re-runs `dal:validate` (working reinstall)
 
-It expects Shopware to be installed already (e.g. via
-[`setup-extension`](../setup-extension/) with `install: true`) and reads the
-database connection from the `DATABASE_URL` environment variable that Shopware
-exposes in CI. It is meant for plugins; apps have no install lifecycle of this
-kind.
+Run it after [`setup-extension`](../setup-extension/) with **`install: true`**,
+which installs and activates the plugin (and thereby already gates the
+container-compile / "does it install on this release" failure from
+shopware/shopware#18086). This action then validates the DAL wiring and the
+uninstall → reinstall round-trip on top. It reads the database connection from
+the `DATABASE_URL` environment variable that Shopware exposes in CI. It is meant
+for plugins; apps have no install lifecycle of this kind.
 
 ## Inputs
 

--- a/plugin-lifecycle/README.md
+++ b/plugin-lifecycle/README.md
@@ -1,0 +1,98 @@
+# Plugin lifecycle validation
+
+Validates a plugin's install / uninstall / reinstall lifecycle and its Data Abstraction Layer (DAL) wiring against an already-installed Shopware.
+
+Use it to catch the class of breakage where a plugin compiles against `trunk` but
+references core symbols or schema that do not exist on the released version a
+merchant runs — the container-compile failure only shows up when the plugin is
+actually installed on that version.
+
+## What it does
+
+1. `plugin:refresh`, then `plugin:install --activate` — boots the container, so a plugin that does not compile against the installed Shopware release fails here
+2. `dal:validate` — validates every registered definition and its associations against the real database schema
+3. `plugin:uninstall`, then asserts the configured tables are gone (clean uninstall)
+4. `plugin:install --activate` again, asserts the configured tables are back, and re-runs `dal:validate` (working reinstall)
+
+It expects Shopware to be installed already (e.g. via
+[`setup-extension`](../setup-extension/) with `install: true`) and reads the
+database connection from the `DATABASE_URL` environment variable that Shopware
+exposes in CI. It is meant for plugins; apps have no install lifecycle of this
+kind.
+
+## Inputs
+
+| Input | Description | Required | Default |
+|-------|-------------|----------|---------|
+| `extensionName` | The plugin (technical) name to validate | Yes | - |
+| `tables` | Whitespace-separated list of tables the plugin owns; asserted dropped on uninstall and recreated on reinstall. Leave empty to validate the lifecycle and DAL only | No | - |
+
+## Usage
+
+Run it as a step in a job that has already set up Shopware, ideally across a
+version matrix so the plugin is validated on the versions merchants actually run.
+
+```yaml
+jobs:
+  lifecycle:
+    strategy:
+      fail-fast: false
+      matrix:
+        shopwareVersion: [v6.7.4.2, trunk]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shopware/github-actions/setup-extension@main
+        with:
+          extensionName: MyPlugin
+          shopwareVersion: ${{ matrix.shopwareVersion }}
+          install: true
+          # Required for older floors whose composer.lock pins a flagged
+          # dependency. No-op on newer versions.
+          allow-insecure-versions: true
+
+      - uses: shopware/github-actions/plugin-lifecycle@main
+        with:
+          extensionName: MyPlugin
+          tables: |
+            my_plugin_foo
+            my_plugin_bar
+```
+
+### Combine with a dynamic version matrix
+
+Pair it with [`versions`](../versions/) so the "latest release" leg of the
+matrix updates itself without a manual bump on every Shopware release:
+
+```yaml
+jobs:
+  versions:
+    runs-on: ubuntu-latest
+    outputs:
+      list: ${{ steps.build.outputs.list }}
+    steps:
+      - uses: shopware/github-actions/versions@main
+        id: resolve
+        with:
+          major: v6.7.
+      - id: build
+        run: echo 'list=["v6.7.4.2", "${{ steps.resolve.outputs.latest-version }}", "trunk"]' >> "$GITHUB_OUTPUT"
+
+  lifecycle:
+    needs: versions
+    strategy:
+      fail-fast: false
+      matrix:
+        shopwareVersion: ${{ fromJSON(needs.versions.outputs.list) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shopware/github-actions/setup-extension@main
+        with:
+          extensionName: MyPlugin
+          shopwareVersion: ${{ matrix.shopwareVersion }}
+          install: true
+          allow-insecure-versions: true
+      - uses: shopware/github-actions/plugin-lifecycle@main
+        with:
+          extensionName: MyPlugin
+          tables: my_plugin_foo my_plugin_bar
+```

--- a/plugin-lifecycle/action.yml
+++ b/plugin-lifecycle/action.yml
@@ -23,8 +23,7 @@ runs:
   steps:
     # install + activate boots the container, so a plugin that does not compile
     # against the installed Shopware release fails here. dal:validate then checks
-    # every registered definition and its associations against the real schema,
-    # catching broken entity/extension wiring on the target version.
+    # every definition and its associations against the real schema.
     - name: Refresh, install & validate DAL
       shell: bash
       env:
@@ -46,8 +45,6 @@ runs:
         php "${GITHUB_WORKSPACE}/bin/console" plugin:uninstall "${EXTENSION_NAME}"
         php "${GITHUB_ACTION_PATH}/assert-tables.php" absent ${TABLES}
 
-    # reinstall must recreate the tables and leave the DAL valid again, proving a
-    # clean install/uninstall/reinstall round-trip on the target version.
     - name: Reinstall, assert tables recreated & re-validate DAL
       shell: bash
       env:

--- a/plugin-lifecycle/action.yml
+++ b/plugin-lifecycle/action.yml
@@ -1,0 +1,59 @@
+name: "Plugin lifecycle validation"
+description: "Validates a plugin's install / uninstall / reinstall lifecycle and DAL wiring against the installed Shopware"
+author: "shopware AG"
+branding:
+  color: "blue"
+  icon: "refresh-cw"
+
+inputs:
+  extensionName:
+    description: "The plugin (technical) name to validate"
+    required: true
+  tables:
+    description: |
+      Optional whitespace-separated list of database tables the plugin owns.
+      When set, the action asserts these tables are dropped on uninstall and
+      recreated on reinstall. Leave empty to validate the lifecycle and DAL
+      wiring only.
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    # install + activate boots the container, so a plugin that does not compile
+    # against the installed Shopware release fails here. dal:validate then checks
+    # every registered definition and its associations against the real schema,
+    # catching broken entity/extension wiring on the target version.
+    - name: Refresh, install & validate DAL
+      shell: bash
+      env:
+        EXTENSION_NAME: ${{ inputs.extensionName }}
+      run: |
+        php "${GITHUB_WORKSPACE}/bin/console" plugin:refresh
+        php "${GITHUB_WORKSPACE}/bin/console" plugin:install --activate --clearCache "${EXTENSION_NAME}"
+        php "${GITHUB_WORKSPACE}/bin/console" dal:validate
+
+    # uninstall drops the plugin's tables; assert they are actually gone (a leaked
+    # table means uninstall is not clean). Done as a CI step rather than a PHPUnit
+    # test because DROP TABLE is not transactional and would break test isolation.
+    - name: Uninstall & assert tables removed
+      shell: bash
+      env:
+        EXTENSION_NAME: ${{ inputs.extensionName }}
+        TABLES: ${{ inputs.tables }}
+      run: |
+        php "${GITHUB_WORKSPACE}/bin/console" plugin:uninstall "${EXTENSION_NAME}"
+        php "${GITHUB_ACTION_PATH}/assert-tables.php" absent ${TABLES}
+
+    # reinstall must recreate the tables and leave the DAL valid again, proving a
+    # clean install/uninstall/reinstall round-trip on the target version.
+    - name: Reinstall, assert tables recreated & re-validate DAL
+      shell: bash
+      env:
+        EXTENSION_NAME: ${{ inputs.extensionName }}
+        TABLES: ${{ inputs.tables }}
+      run: |
+        php "${GITHUB_WORKSPACE}/bin/console" plugin:install --activate --clearCache "${EXTENSION_NAME}"
+        php "${GITHUB_ACTION_PATH}/assert-tables.php" present ${TABLES}
+        php "${GITHUB_WORKSPACE}/bin/console" dal:validate

--- a/plugin-lifecycle/action.yml
+++ b/plugin-lifecycle/action.yml
@@ -21,17 +21,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-    # install + activate boots the container, so a plugin that does not compile
-    # against the installed Shopware release fails here. dal:validate then checks
-    # every definition and its associations against the real schema.
-    - name: Refresh, install & validate DAL
+    # setup-extension (install: true) has already installed and activated the
+    # plugin, so start by validating: dal:validate checks every definition and its
+    # associations against the real schema, catching entity/extension wiring
+    # broken on the target version.
+    - name: Validate DAL
       shell: bash
-      env:
-        EXTENSION_NAME: ${{ inputs.extensionName }}
-      run: |
-        php "${GITHUB_WORKSPACE}/bin/console" plugin:refresh
-        php "${GITHUB_WORKSPACE}/bin/console" plugin:install --activate --clearCache "${EXTENSION_NAME}"
-        php "${GITHUB_WORKSPACE}/bin/console" dal:validate
+      run: php "${GITHUB_WORKSPACE}/bin/console" dal:validate
 
     # uninstall drops the plugin's tables; assert they are actually gone (a leaked
     # table means uninstall is not clean). Done as a CI step rather than a PHPUnit

--- a/plugin-lifecycle/assert-tables.php
+++ b/plugin-lifecycle/assert-tables.php
@@ -39,9 +39,14 @@ $pdo = new PDO(
     isset($parts['pass']) ? urldecode($parts['pass']) : ''
 );
 
+$stmt = $pdo->prepare(
+    'SELECT COUNT(*) FROM information_schema.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ?'
+);
+
 $failed = false;
 foreach ($tables as $table) {
-    $exists = $pdo->query('SHOW TABLES LIKE ' . $pdo->quote($table))->fetch() !== false;
+    $stmt->execute([$table]);
+    $exists = (int) $stmt->fetchColumn() > 0;
 
     if ($mode === 'absent' && $exists) {
         fwrite(STDERR, "::error::Table $table still exists after uninstall\n");

--- a/plugin-lifecycle/assert-tables.php
+++ b/plugin-lifecycle/assert-tables.php
@@ -1,0 +1,63 @@
+<?php declare(strict_types=1);
+
+/**
+ * Asserts that a set of database tables is present or absent.
+ *
+ * Usage: php assert-tables.php <present|absent> [table ...]
+ *
+ * The database connection is read from the DATABASE_URL environment variable,
+ * which Shopware exposes in CI. With no tables given the script is a no-op, so
+ * plugins that own no tables can call the action without configuring anything.
+ */
+
+$mode = $argv[1] ?? '';
+if (!in_array($mode, ['present', 'absent'], true)) {
+    fwrite(STDERR, "Usage: assert-tables.php <present|absent> [table ...]\n");
+    exit(2);
+}
+
+$tables = array_slice($argv, 2);
+if ($tables === []) {
+    exit(0);
+}
+
+$url = (string) getenv('DATABASE_URL');
+if ($url === '') {
+    fwrite(STDERR, "::error::DATABASE_URL is not set\n");
+    exit(2);
+}
+
+$parts = parse_url($url);
+if ($parts === false || !isset($parts['host'], $parts['path'])) {
+    fwrite(STDERR, "::error::Could not parse DATABASE_URL\n");
+    exit(2);
+}
+
+$pdo = new PDO(
+    sprintf('mysql:host=%s;port=%d;dbname=%s', $parts['host'], $parts['port'] ?? 3306, ltrim($parts['path'], '/')),
+    $parts['user'] ?? 'root',
+    isset($parts['pass']) ? urldecode($parts['pass']) : ''
+);
+
+$failed = false;
+foreach ($tables as $table) {
+    $exists = $pdo->query('SHOW TABLES LIKE ' . $pdo->quote($table))->fetch() !== false;
+
+    if ($mode === 'absent' && $exists) {
+        fwrite(STDERR, "::error::Table $table still exists after uninstall\n");
+        $failed = true;
+    }
+
+    if ($mode === 'present' && !$exists) {
+        fwrite(STDERR, "::error::Table $table was not recreated after reinstall\n");
+        $failed = true;
+    }
+}
+
+if ($failed) {
+    exit(1);
+}
+
+echo $mode === 'absent'
+    ? "All configured tables removed after uninstall\n"
+    : "All configured tables present after reinstall\n";


### PR DESCRIPTION
## Summary

Adds a composite action `plugin-lifecycle` that validates a plugin's uninstall/reinstall lifecycle and DAL wiring against an already-installed Shopware — complementing the container-compile gate that `setup-extension` already provides, i.e. the class of breakage from [shopware/shopware#18086](https://github.com/shopware/shopware/issues/18086) where SwagDynamicAccess compiled on `trunk` but failed to install on the released version merchants actually ran.

## What it does

Run it after `setup-extension` with `install: true` (which installs + activates the plugin — that step already gates a plugin that doesn't compile on the target release). This action then:

1. `dal:validate` — validates every registered definition + associations against the real schema
2. `plugin:uninstall` → assert the configured tables are gone (clean uninstall)
3. `plugin:install --activate` → assert tables recreated + re-run `dal:validate` (working reinstall)

## Design notes

- **Composite action, not a reusable workflow** — it drops into an existing test job right after `setup-extension`, reusing the single Shopware install instead of forcing a second one. Matches the granularity of `setup-extension` / `phpunit` / `versions`.
- **`tables` input is optional** — the one plugin-specific bit becomes a caller input; omit it and you still get the uninstall/reinstall + `dal:validate` checks. Table existence is checked in a small `assert-tables.php` helper (exact `information_schema` lookup, reads `DATABASE_URL`) referenced via `${GITHUB_ACTION_PATH}`.
- Composes with [`versions`](../versions/) for a self-updating version matrix (see the action README).

## Testing

- `test.yml` gains a `plugin-lifecycle-assert-tables` job that runs the `assert-tables.php` helper against a MySQL service — present/absent for an existing and a missing table, plus the empty-table-list no-op. Mirrors the repo's existing helper-script test convention (`downstream-wait`).
- The install/uninstall/reinstall command sequence is already proven green in SwagDynamicAccess's own CI (that's where this was extracted from); `test.yml` deliberately does not boot a full Shopware, matching how the other install-heavy actions are handled here.

Extracted from the SwagDynamicAccess CI so every plugin can reuse it without copy-pasting the bash/PDO lifecycle logic.