### PR TITLE
fix(setup-extension): retry dependency clone on transient network errors

### DIFF
--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -220,7 +220,18 @@ runs:
             export GH_TOKEN="${dep_token}"
           fi
 
-          git clone "$dep_repo" "custom/plugins/$dep_name"
+          for attempt in 1 2 3; do
+            if git clone "$dep_repo" "custom/plugins/$dep_name"; then
+              break
+            fi
+            rm -rf "custom/plugins/$dep_name"
+            if [ "${attempt}" -eq 3 ]; then
+              echo "::error::cloning ${dep_name} failed after ${attempt} attempts"
+              exit 1
+            fi
+            echo "::warning::cloning ${dep_name} failed (attempt ${attempt}/3); retrying in $((attempt * 5))s"
+            sleep "$((attempt * 5))"
+          done
 
           if [ -n "${dep_branch}" ]; then
             if [ "${dep_branch}" = ".auto" ]; then


### PR DESCRIPTION
Closes #179

Wraps the `git clone` in the `Clone Dependencies` step in a 3-attempt retry with backoff (5s, 10s), mirroring the `npm-ci-retry` idiom. A partial clone directory is removed before each retry; after the third failed attempt the step emits an `::error::` annotation and exits 1 as before.
