### PR TITLE
ci: use partial clone for extension dependencies 

### DIFF
--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -238,7 +238,9 @@ runs:
           fi
 
           for attempt in 1 2 3; do
-            if git clone "$dep_repo" "custom/plugins/$dep_name"; then
+            # Partial clone (lazy blobs): full ref list for the .auto branch checkout below,
+            # but skips historic blobs, which drastically reduces transfer size for large repos
+            if git clone --filter=blob:none "$dep_repo" "custom/plugins/$dep_name"; then
               break
             fi
             rm -rf "custom/plugins/$dep_name"


### PR DESCRIPTION
## Problem

Since 2026-07-18, Downstream workflows (e.g. in `shopware/Rufus`) fail in **30–50 % of runs** while cloning `SwagCommercial`:

```
fatal: unable to access 'https://github.com/shopware/SwagCommercial.git/': Failed sending HTTP request
##[error]cloning SwagCommercial failed after 3 attempts
```

Failure rate per hour (Downstream workflow, shopware/Rufus):

| Period | Runs | Failed |
|---|---|---|
| Jul 18, 21h | 14 | 6 |
| Jul 20, 08h | 22 | 7 |
| Jul 20, 09h | 32 | 11 |

All failures have the identical signature: the connection is rejected immediately (all 3 retry attempts fail within ~0.2 s each). SwagCommercial is simply the *first* dependency in the clone loop, so it always takes the hit. The pattern (instant connection failures, correlated with run volume, self-hosted runners behind shared NAT egress) points to throttling of the runner egress IPs, driven by the volume of full-history clones (~140 MB packed per clone, 30+ runs/hour).

## Change

Clone dependencies with `--filter=blob:none` (partial clone, lazy blobs):

- All branches/refs remain available, so the `.auto` branch resolution and the subsequent `git checkout` keep working unchanged (verified: branch checkout on a partial clone lazy-fetches the needed blobs transparently, using the same auth extraheader).
- Historic blobs are no longer transferred, cutting per-clone traffic to a fraction and reducing both the throttling pressure and the failure window.

## Notes

- Composer `path`-type repos are unaffected (working tree is fully materialized).
- `vcs`-type repos on the cloned path may lazy-fetch blobs on demand; the per-repo auth header set in the clone loop persists for the job, so those fetches authenticate fine.
- This does not fully rule out the throttling issue — if failures persist, the retry/backoff should be extended and the egress IP situation raised with GitHub support.