### PR TITLE
ci: retry dependency clones with HTTP/1.1 and verbose transfer log

### DIFF
--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -238,9 +238,19 @@ runs:
           fi
 
           for attempt in 1 2 3; do
+            git_flags=()
+            if [ "${attempt}" -gt 1 ]; then
+              # 'Failed sending HTTP request' (curl error 55) is a typical symptom of an
+              # HTTP/2 stream reset while the request body is being sent. Retry attempts
+              # force HTTP/1.1 and log the transfer verbosely (auth headers are redacted
+              # by git) so we can pin down where the connection breaks.
+              git_flags+=(-c http.version=HTTP/1.1)
+              export GIT_CURL_VERBOSE=1
+            fi
             # Partial clone (lazy blobs): full ref list for the .auto branch checkout below,
             # but skips historic blobs, which drastically reduces transfer size for large repos
-            if git clone --filter=blob:none "$dep_repo" "custom/plugins/$dep_name"; then
+            if git "${git_flags[@]}" clone --filter=blob:none "$dep_repo" "custom/plugins/$dep_name"; then
+              unset GIT_CURL_VERBOSE
               break
             fi
             rm -rf "custom/plugins/$dep_name"
@@ -251,6 +261,7 @@ runs:
             echo "::warning::cloning ${dep_name} failed (attempt ${attempt}/3); retrying in $((attempt * 5))s"
             sleep "$((attempt * 5))"
           done
+          unset GIT_CURL_VERBOSE
 
           if [ -n "${dep_branch}" ]; then
             if [ "${dep_branch}" = ".auto" ]; then


### PR DESCRIPTION
## Context

Follow-up to #181, which did **not** resolve the intermittent `Failed sending HTTP request` errors when cloning SwagCommercial (e.g. [this run](https://github.com/shopware/Rufus/actions/runs/29737261542/job/88335465740)).

## What we know now

- The failures occur within **~60 ms**, before any pack data is transferred → transfer volume is not the bottleneck (hence #181 alone couldn't fix it).
- curl error 55 at that stage is a typical symptom of an **HTTP/2 stream reset while the request body is being sent**.
- SwagCommercial's fetch negotiation request is ~15× larger than that of the other dependencies (**3707 refs vs ~250**) — consistent with it being the only repo affected.
- None of the involved actions changed when the failures started (2026-07-18): `setup-extension` unchanged since 06-11, `setup-shopware` since 06-08 → points at a runner-image or transport-level change (runners now ship git 2.54.0).

## Change

Retry attempts (2 and 3) now:
- force `http.version=HTTP/1.1`
- enable `GIT_CURL_VERBOSE` (git redacts auth headers in these traces)

First attempts stay on the default transport, so the logs become a live experiment:
- **retries succeed while first attempts keep failing** → HTTP/2 confirmed as trigger; we can then force HTTP/1.1 for the first attempt too (or fix the runner image)
- **retries keep failing** → the verbose trace shows exactly where the connection breaks (DNS, TLS, request send), which is what GitHub support / runs-on will ask for anyway