### PR TITLE
fix: allow insecure versions in admin-jest

### DIFF
--- a/.github/workflows/admin-jest.yml
+++ b/.github/workflows/admin-jest.yml
@@ -52,6 +52,7 @@ jobs:
           install: true
           install-admin: true
           env: prod
+          allow-insecure-versions: true
           extraRepositories: |
             {
               "${{ github.event.repository.name }}": {


### PR DESCRIPTION
Pass `allow-insecure-versions: true` to `setup-extension` in the `admin-jest` reusable workflow, matching `phpstan`, `phpunit` and `e2e`.

This change allows CI runs with a compatibility matrix to use older, known insecure versions.

Fixes https://github.com/shopware/SwagDynamicAccess/issues/55