### PR TITLE
ci(setup-extension): allow skipping plugin installation

### DIFF
--- a/setup-extension/action.yml
+++ b/setup-extension/action.yml
@@ -73,6 +73,11 @@ inputs:
     required: false
     default: ""
 
+  install-plugin:
+    description: Whether to refresh and install the extension plugin after setting up Shopware
+    required: false
+    default: "true"
+
   install-admin:
     description: Whether to install administration npm dependencies
     required: false
@@ -294,7 +299,7 @@ runs:
       run: composer require $(composer -d custom/plugins/${{ inputs.extensionName }} config name) --with-dependencies
 
     - name: Refresh Plugins
-      if: ${{ inputs.install == 'true' && env.IS_PLUGIN == 'true' }}
+      if: ${{ inputs.install == 'true' && inputs.install-plugin == 'true' && env.IS_PLUGIN == 'true' }}
       shell: bash
       run: php bin/console plugin:refresh
 
@@ -311,7 +316,7 @@ runs:
         done
 
     - name: Install Plugin
-      if: ${{ inputs.install == 'true' && env.IS_PLUGIN == 'true' }}
+      if: ${{ inputs.install == 'true' && inputs.install-plugin == 'true' && env.IS_PLUGIN == 'true' }}
       shell: bash
       run: php bin/console plugin:install --activate ${{ inputs.extensionName }}
 


### PR DESCRIPTION
## What changed

Adds an opt-in `install-plugin` input to `setup-extension`. It defaults to `true`, preserving existing consumers, and gates only the plugin refresh and installation steps.

## Why

PHPUnit integrations whose test bootstrap reinstalls the calling plugin can avoid the redundant first refresh/install phase while retaining Shopware and database initialization.

## Validation

- `git diff --check`
- Ruby YAML parse of `setup-extension/action.yml`
- Commercial Integration workflow updated to exercise `install-plugin: false`