### PR TITLE
fix: avoid double-zipping build artifacts

### DIFF
--- a/build-zip/README.md
+++ b/build-zip/README.md
@@ -8,7 +8,7 @@ Builds the extension zip and validates it using shopware-cli.
 2. Installs shopware-cli
 3. Builds the extension zip using shopware-cli
 4. Validates the zip file
-5. Uploads the artifact
+5. Uploads the extension zip directly, without wrapping it in another zip
 
 ## Inputs
 

--- a/build-zip/action.yml
+++ b/build-zip/action.yml
@@ -54,5 +54,7 @@ runs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       id: upload
       with:
-        name: ${{ inputs.extensionName }}.zip
         path: ${{ inputs.extensionName }}.zip
+        # The extension is already a zip, so upload it directly without an
+        # additional artifact archive around it.
+        archive: false


### PR DESCRIPTION
## Summary

- upload the generated extension ZIP directly with upload-artifact v7
- avoid wrapping the extension ZIP in another artifact archive
- document the resulting single-ZIP behavior

## Validation

- build-zip action definition check
- git diff --check
- bash downstream/wait.test.bash
- bash setup-extension/action.test.bash
- bash version-bump/version-bump.test.bash